### PR TITLE
Fix asset path casing in coffee_clicker

### DIFF
--- a/coffee_clicker/index.html
+++ b/coffee_clicker/index.html
@@ -30,12 +30,12 @@ window.onload = function(){
   let reportBg, reportLine1, reportLine2, reportLine3;
 
   function preload(){
-    this.load.image('bg','assets/BG.PNG');
-    this.load.image('truck','assets/Truck.PNG');
-    this.load.image('girl','assets/CoffeeGirl.PNG');
+    this.load.image('bg','assets/bg.png');
+    this.load.image('truck','assets/truck.png');
+    this.load.image('girl','assets/coffeegirl.png');
     for(let r=0;r<5;r++)for(let c=0;c<6;c++){
       const k=`new_kid_${r}_${c}`; keys.push(k);
-      this.load.image(k,`assets/GenZ/${k}.png`);
+      this.load.image(k,`assets/genz/${k}.png`);
     }
   }
 


### PR DESCRIPTION
## Summary
- fix asset paths in `index.html` to match filesystem casing
- verify images load correctly from a case-sensitive HTTP server

## Testing
- `curl -I http://localhost:8000/coffee_clicker/assets/bg.png`
- `curl -I http://localhost:8000/coffee_clicker/assets/truck.png`
- `curl -I http://localhost:8000/coffee_clicker/assets/coffeegirl.png`
- `curl -I http://localhost:8000/coffee_clicker/assets/genz/new_kid_0_0.png`

------
https://chatgpt.com/codex/tasks/task_e_6849f4c85120832fb0657515554e203a