### PR TITLE
Adjust sales report design

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-  <title>Coffee Clicker Game v53</title>
+  <title>Coffee Club</title>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
   <style>
     html, body, #game-container { margin:0; padding:0; width:100%; height:100%; overflow:hidden; }
@@ -15,6 +15,7 @@
 <script>
 window.onload = function(){
   const COFFEE_COST=5.00, WATER_COST=5.58;
+  const VERSION='54';
   const SPAWN_DELAY=500;
   const MAX_M=100, MAX_L=100;
   let money=10.00, love=10, gameOver=false, customer=null, coins=0, req='coffee';
@@ -25,9 +26,9 @@ window.onload = function(){
     pixelArt:true, scene:{ preload, create } };
   new Phaser.Game(config);
 
-  let moneyText, loveText;
+  let moneyText, loveText, versionText;
   let dialogBg, dialogText, dialogCoins, btnSell, btnGive, btnRef;
-  let reportBg, reportLine1, reportLine2, reportLine3;
+  let reportBg, reportLine1, reportLine2, reportLine3, reportLine4;
 
   function preload(){
     this.load.image('bg','assets/bg.png');
@@ -47,6 +48,8 @@ window.onload = function(){
     // HUD
     moneyText=this.add.text(20,20,'🪙 '+money.toFixed(2),{font:'20px sans-serif',fill:'#000'}).setDepth(1);
     loveText=this.add.text(20,50,'❤️ '+love,{font:'20px sans-serif',fill:'#000'}).setDepth(1);
+    versionText=this.add.text(10,630,'v'+VERSION,{font:'12px sans-serif',fill:'#000'})
+      .setOrigin(0,1).setDepth(1);
 
     // truck & girl
     this.add.image(240,245,'truck').setScale(0.924).setDepth(2);
@@ -66,11 +69,18 @@ window.onload = function(){
     btnRef=this.add.text(360,500,'Refuse',{font:'18px sans-serif',fill:'#fff',backgroundColor:'#800000',padding:{x:12,y:6}})
       .setInteractive().setVisible(false).setDepth(12).on('pointerdown',()=>handleAction.call(this,'refuse'));
 
-    // report
-    reportBg=this.add.rectangle(240,200,220,80,0xffffff).setStrokeStyle(2,0x000).setVisible(false).setDepth(10);
-    reportLine1=this.add.text(240,180,'',{font:'16px sans-serif',fill:'#000'}).setOrigin(0.5).setVisible(false).setDepth(11);
-    reportLine2=this.add.text(240,200,'',{font:'16px sans-serif',fill:'#000'}).setOrigin(0.5).setVisible(false).setDepth(11);
-    reportLine3=this.add.text(240,220,'',{font:'16px sans-serif',fill:'#000'}).setOrigin(0.5).setVisible(false).setDepth(11);
+    // report positioned like a small receipt
+    const rX=330, rY=120;
+    reportBg=this.add.rectangle(rX,rY,160,100,0xffffff)
+      .setStrokeStyle(2,0x000).setVisible(false).setDepth(10);
+    reportLine1=this.add.text(rX,rY-25,'',{font:'13px sans-serif',fill:'#000'})
+      .setOrigin(0.5).setVisible(false).setDepth(11);
+    reportLine2=this.add.text(rX,rY-5,'',{font:'13px sans-serif',fill:'#000'})
+      .setOrigin(0.5).setVisible(false).setDepth(11);
+    reportLine3=this.add.text(rX,rY+15,'',{font:'13px sans-serif',fill:'#000'})
+      .setOrigin(0.5).setVisible(false).setDepth(11);
+    reportLine4=this.add.text(rX,rY+35,'',{font:'13px sans-serif',fill:'#000'})
+      .setOrigin(0.5).setVisible(false).setDepth(11);
 
     this.time.delayedCall(SPAWN_DELAY,spawnCustomer,[],this);
   }
@@ -113,22 +123,29 @@ window.onload = function(){
     money=+(money+mD).toFixed(2); love+=lD;
     moneyText.setText('🪙 '+money.toFixed(2)); loveText.setText('❤️ '+love);
 
-    // show report
+    // show report in receipt style
+    const cost=(req==='coffee'?COFFEE_COST:WATER_COST);
     reportBg.setVisible(true);
-    reportLine1.setText(type==='sell'?`+$${COFFEE_COST.toFixed(2)}`:(type==='give'?`-$${(-mD).toFixed(2)}`:''));
-    reportLine2.setText(type==='sell'?`Tip +$${tip.toFixed(2)}`:'');
-    reportLine3.setText(lD > 0 ? '❤️'.repeat(lD) : (lD < 0 ? ('😠'.repeat(-lD)) : ''));
-    reportLine1.setVisible(true); reportLine2.setVisible(type==='sell'); reportLine3.setVisible(true);
+    reportLine1.setText(`$${cost.toFixed(2)}`);
+    reportLine2.setText(type==='sell'?'Paid':'Unpaid')
+      .setColor(type==='sell'?'#008000':'#800000');
+    const tipPct=type==='sell'?lD*15:0;
+    reportLine3.setText(`Tip: ${tipPct}% $${(type==='sell'?tip:0).toFixed(2)}`);
+    reportLine4.setText(lD>0?'❤️'.repeat(lD):(lD<0?'😠'.repeat(-lD):''));
+    reportLine1.setVisible(true); reportLine2.setVisible(true);
+    reportLine3.setVisible(true); reportLine4.setVisible(true);
 
-    // float up and hide in 400ms
-    this.tweens.add({ targets: [reportBg, reportLine1, reportLine2, reportLine3],
-      y: '-=50', alpha:0, duration:400, callbackScope:this,
-      onComplete: ()=>{ 
-        reportBg.setVisible(false).alpha=1; reportBg.y+=50;
-        reportLine1.setVisible(false).alpha=1; reportLine1.y+=50;
-        reportLine2.setVisible(false).alpha=1; reportLine2.y+=50;
-        reportLine3.setVisible(false).alpha=1; reportLine3.y+=50;
-      }
+    this.time.delayedCall(1000,()=>{
+      this.tweens.add({ targets:[reportBg,reportLine1,reportLine2,reportLine3,reportLine4],
+        alpha:0, duration:3000, callbackScope:this,
+        onComplete:()=>{
+          reportBg.setVisible(false).alpha=1;
+          reportLine1.setVisible(false).alpha=1;
+          reportLine2.setVisible(false).alpha=1;
+          reportLine3.setVisible(false).alpha=1;
+          reportLine4.setVisible(false).alpha=1;
+        }
+      });
     });
 
     // exit customer and next spawn


### PR DESCRIPTION
## Summary
- rename page title to "Coffee Club"
- add version constant and show version at bottom left
- reposition and shrink receipt UI
- simplify receipt text and color 'Paid/Unpaid'
- hold report for 1s then fade out over 3s without moving

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b21b05db8832fb00b2777ed885650