### PR TITLE
Revamp sale report animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,20 +70,16 @@ window.onload = function(){
     btnRef=this.add.text(360,500,'Refuse',{font:'18px sans-serif',fill:'#fff',backgroundColor:'#800000',padding:{x:12,y:6}})
       .setInteractive().setVisible(false).setDepth(12).on('pointerdown',()=>handleAction.call(this,'refuse'));
 
-    // report positioned like a small receipt
-
-
-    const rX=360, rY=150;
-    reportBg=this.add.rectangle(rX,rY,180,120,0xffffff)
-      .setStrokeStyle(2,0x000).setVisible(false).setDepth(10);
-    reportLine1=this.add.text(rX,rY-30,'',{font:'14px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setVisible(false).setDepth(11);
-    reportLine2=this.add.text(rX,rY-10,'',{font:'14px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setVisible(false).setDepth(11);
-    reportLine3=this.add.text(rX,rY+10,'',{font:'14px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setVisible(false).setDepth(11);
-    reportLine4=this.add.text(rX,rY+30,'',{font:'14px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setVisible(false).setDepth(11);
+    // sliding report texts
+    reportBg=this.add.rectangle(0,0,0,0,0xffffff).setVisible(false);
+    reportLine1=this.add.text(480,moneyText.y,'',{font:'16px sans-serif',fill:'#000'})
+      .setOrigin(0,0.5).setVisible(false).setDepth(11);
+    reportLine2=this.add.text(480,moneyText.y+20,'',{font:'16px sans-serif',fill:'#000'})
+      .setOrigin(0,0.5).setVisible(false).setDepth(11);
+    reportLine3=this.add.text(480,loveText.y,'',{font:'16px sans-serif',fill:'#000'})
+      .setOrigin(0,0.5).setVisible(false).setDepth(11);
+    reportLine4=this.add.text(0,0,'',{font:'14px sans-serif',fill:'#000'})
+      .setVisible(false);
 
     this.time.delayedCall(SPAWN_DELAY,spawnCustomer,[],this);
   }
@@ -123,47 +119,63 @@ window.onload = function(){
     } else {
       lD=-Phaser.Math.Between(1,3);
     }
-    money=+(money+mD).toFixed(2); love+=lD;
-    moneyText.setText('🪙 '+money.toFixed(2)); loveText.setText('❤️ '+love);
 
-    // show report in receipt style
     const cost=(req==='coffee'?COFFEE_COST:WATER_COST);
-    reportBg.setVisible(true);
-
-
-    reportLine1.setText(`Price: $${cost.toFixed(2)}`);
-    reportLine2.setText(`Paid: $${(type==='sell'?cost:0).toFixed(2)}`);
     const tipPct=type==='sell'?lD*15:0;
-    reportLine3.setText(`Tip: ${tipPct}% $${(type==='sell'?tip:0).toFixed(2)}`);
-    reportLine4.setText(lD>0?'❤️'.repeat(lD):(lD<0?'😠'.repeat(-lD):''));
-    reportLine1.setVisible(true); reportLine2.setVisible(true);
-    reportLine3.setVisible(true); reportLine4.setVisible(true);
 
+    const finish=()=>{
+      this.tweens.add({ targets: customer, x: (type==='refuse'? -50:520), duration:600, callbackScope:this,
+        onComplete:()=>{
+          customer.destroy(); customer=null;
+          if(money<=0){showEnd.call(this,'Game Over\nYou are fired');return;}
+          if(love<=0){showEnd.call(this,'Game Over 😠');return;}
+          if(money>=MAX_M){showEnd.call(this,'Congrats! 💰');return;}
+          if(love>=MAX_L){showEnd.call(this,'Victory! ❤️');return;}
+          this.time.delayedCall(SPAWN_DELAY, spawnCustomer, [], this);
+        }
+      });
+    };
 
+    // price slide in
+    if(type!=='refuse'){
+      reportLine1.setStyle({fill:'#000'}).setText(`$${cost.toFixed(2)}`)
+        .setPosition(480,moneyText.y).setVisible(true);
+      this.tweens.add({ targets: reportLine1, x:240, duration:500, callbackScope:this,
+        onComplete:()=>{
+          reportLine1.setText(`Paid $${(type==='sell'?cost:0).toFixed(2)}`).setColor('#008000');
+        }
+      });
 
-    // float up and hide slowly over 3s
-    this.tweens.add({ targets: [reportBg, reportLine1, reportLine2, reportLine3, reportLine4],
-      y: '-=50', alpha:0, duration:3000, callbackScope:this,
-      onComplete: ()=>{
-        reportBg.setVisible(false).alpha=1; reportBg.y+=50;
-        reportLine1.setVisible(false).alpha=1; reportLine1.y+=50;
-        reportLine2.setVisible(false).alpha=1; reportLine2.y+=50;
-        reportLine3.setVisible(false).alpha=1; reportLine3.y+=50;
-        reportLine4.setVisible(false).alpha=1; reportLine4.y+=50;
-      }
-    });
+      this.time.delayedCall(500,()=>{
+        reportLine2.setText(`Tip: ${tipPct}% $${(type==='sell'?tip:0).toFixed(2)}`)
+          .setPosition(480,moneyText.y+20).setColor('#000').setVisible(true);
+        this.tweens.add({ targets:reportLine2, x:240, duration:500 });
+      },[],this);
+    }
 
-    // exit customer and next spawn
-    this.tweens.add({ targets: customer, x: (type==='refuse'? -50:520), duration:600, callbackScope:this,
-      onComplete:()=>{
-        customer.destroy(); customer=null;
-        if(money<=0){showEnd.call(this,'Game Over\nYou are fired');return;}
-        if(love<=0){showEnd.call(this,'Game Over 😠');return;}
-        if(money>=MAX_M){showEnd.call(this,'Congrats! 💰');return;}
-        if(love>=MAX_L){showEnd.call(this,'Victory! ❤️');return;}
-        this.time.delayedCall(SPAWN_DELAY, spawnCustomer, [], this);
-      }
-    });
+    if(lD!==0){
+      reportLine3.setText(lD>0?'❤️'.repeat(lD):'😠'.repeat(-lD))
+        .setPosition(480,loveText.y).setVisible(true);
+      this.tweens.add({ targets:reportLine3, x:240, duration:500, delay:500 });
+    }
+
+    this.time.delayedCall(1500,()=>{
+      const targets=[];
+      if(type!=='refuse'){ targets.push(reportLine1,reportLine2); }
+      if(lD!==0) targets.push(reportLine3);
+      this.tweens.add({ targets, x:moneyText.x, alpha:0, duration:600, callbackScope:this,
+        onComplete:()=>{
+          if(type!=='refuse'){
+            reportLine1.setVisible(false).alpha=1;
+            reportLine2.setVisible(false).alpha=1;
+          }
+          if(lD!==0){ reportLine3.setVisible(false).alpha=1; }
+          money=+(money+mD).toFixed(2); love+=lD;
+          moneyText.setText('🪙 '+money.toFixed(2)); loveText.setText('❤️ '+love);
+          finish();
+        }
+      });
+    },[],this);
   }
 
   function showEnd(msg){


### PR DESCRIPTION
## Summary
- redesign sale report to slide in from the right
- slide info to the HUD and update scores when animation completes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b29a68470832fb383ec7693752f86