### PR TITLE
Improve sales report animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,43 +138,63 @@ window.onload = function(){
 
     // price slide in
     if(type!=='refuse'){
-      reportLine1.setStyle({fill:'#000'}).setText(`$${cost.toFixed(2)}`)
+      reportLine1.setStyle({fill:'#000'})
+        .setText(`$${cost.toFixed(2)}`)
         .setPosition(480,moneyText.y).setVisible(true);
-      this.tweens.add({ targets: reportLine1, x:240, duration:500, callbackScope:this,
+      this.tweens.add({targets:reportLine1,x:240,duration:500,callbackScope:this,
         onComplete:()=>{
-          reportLine1.setText(`Paid $${(type==='sell'?cost:0).toFixed(2)}`).setColor('#008000');
+          reportLine1.setText(`Paid $${cost.toFixed(2)}`)
+            .setColor('#008000');
         }
       });
 
-      this.time.delayedCall(500,()=>{
-        reportLine2.setText(`Tip: ${tipPct}% $${(type==='sell'?tip:0).toFixed(2)}`)
-          .setPosition(480,moneyText.y+20).setColor('#000').setVisible(true);
-        this.tweens.add({ targets:reportLine2, x:240, duration:500 });
+      this.time.delayedCall(250,()=>{
+        reportLine2.setText(`Tip ${tipPct}%`)
+          .setStyle({fontSize:'14px',fill:'#000'})
+          .setPosition(480,reportLine1.y+18).setVisible(true);
+        reportLine3.setText(`$${tip.toFixed(2)}`)
+          .setStyle({fontSize:'16px',fill:'#000'})
+          .setPosition(480,reportLine2.y+18).setVisible(true);
+        this.tweens.add({targets:[reportLine2,reportLine3],x:240,duration:500});
       },[],this);
     }
 
     if(lD!==0){
-      reportLine3.setText(lD>0?'❤️'.repeat(lD):'😠'.repeat(-lD))
+      reportLine4.setText(lD>0?'❤️'.repeat(lD):'😠'.repeat(-lD))
         .setPosition(480,loveText.y).setVisible(true);
-      this.tweens.add({ targets:reportLine3, x:240, duration:500, delay:500 });
+      this.tweens.add({targets:reportLine4,x:240,duration:500});
     }
 
-    this.time.delayedCall(1500,()=>{
-      const targets=[];
-      if(type!=='refuse'){ targets.push(reportLine1,reportLine2); }
-      if(lD!==0) targets.push(reportLine3);
-      this.tweens.add({ targets, x:moneyText.x, alpha:0, duration:600, callbackScope:this,
-        onComplete:()=>{
-          if(type!=='refuse'){
+    this.time.delayedCall(1000,()=>{
+      let pending=(type!=='refuse'?1:0)+(lD!==0?1:0);
+      const done=()=>{ if(--pending<=0) finish(); };
+
+      if(type!=='refuse'){
+        this.tweens.add({targets:[reportLine1,reportLine2,reportLine3],
+          x:moneyText.x,alpha:0,duration:600,callbackScope:this,
+          onComplete:()=>{
             reportLine1.setVisible(false).alpha=1;
             reportLine2.setVisible(false).alpha=1;
+            reportLine3.setVisible(false).alpha=1;
+            money=+(money+mD).toFixed(2);
+            moneyText.setText('🪙 '+money.toFixed(2));
+            done();
           }
-          if(lD!==0){ reportLine3.setVisible(false).alpha=1; }
-          money=+(money+mD).toFixed(2); love+=lD;
-          moneyText.setText('🪙 '+money.toFixed(2)); loveText.setText('❤️ '+love);
-          finish();
-        }
-      });
+        });
+      }
+
+      if(lD!==0){
+        this.tweens.add({targets:reportLine4,x:loveText.x,alpha:0,duration:600,
+          callbackScope:this,
+          onComplete:()=>{
+            reportLine4.setVisible(false).alpha=1;
+            love+=lD;
+            loveText.setText('❤️ '+love);
+            done();
+          }
+        });
+      }
+      if(pending===0) finish();
     },[],this);
   }
 


### PR DESCRIPTION
## Summary
- refactor `handleAction` sliding report lines
- update tip and heart animations to center then fade

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b2d88c2f4832f80fda820e5b78577