### PR TITLE
Animate intro sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,15 @@ window.onload = function(){
       .setOrigin(0,1).setDepth(1);
 
     // truck & girl
-    this.add.image(240,245,'truck').setScale(0.924).setDepth(2);
-    this.add.image(240,292,'girl').setScale(0.5).setDepth(3);
+    const truck=this.add.image(520,245,'truck').setScale(0.924).setDepth(2);
+    const girl=this.add.image(520,210,'girl').setScale(0.5).setDepth(3)
+      .setVisible(false);
+
+    const intro=this.tweens.createTimeline({callbackScope:this,
+      onComplete:()=>this.time.delayedCall(SPAWN_DELAY,spawnCustomer,[],this)});
+    intro.add({targets:[truck,girl],x:240,duration:800});
+    intro.add({targets:girl,y:292,duration:500,onStart:()=>girl.setVisible(true)});
+    intro.play();
 
     // dialog
     dialogBg=this.add.rectangle(240,460,460,120,0xffffff).setStrokeStyle(2,0x000).setVisible(false).setDepth(10);
@@ -79,8 +86,6 @@ window.onload = function(){
       .setOrigin(0,0.5).setVisible(false).setDepth(11);
     reportLine4=this.add.text(0,0,'',{font:'14px sans-serif',fill:'#000'})
       .setVisible(false);
-
-    this.time.delayedCall(SPAWN_DELAY,spawnCustomer,[],this);
   }
 
   function spawnCustomer(){


### PR DESCRIPTION
## Summary
- animate truck arriving on screen using a timeline
- hide the coffee girl until the truck stops then drop her down
- trigger the first customer spawn after the intro finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b320e303c832f9957827495a803e9