### PR TITLE
Improve score animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,20 +48,20 @@ window.onload = function(){
     bg.setDisplaySize(this.scale.width,this.scale.height);
 
     // HUD
-    moneyText=this.add.text(20,20,'🪙 '+money.toFixed(2),{font:'20px sans-serif',fill:'#000'}).setDepth(1);
-    loveText=this.add.text(20,50,'❤️ '+love,{font:'20px sans-serif',fill:'#000'}).setDepth(1);
+    moneyText=this.add.text(20,20,'🪙 '+money.toFixed(2),{font:'24px sans-serif',fill:'#fff'}).setDepth(1);
+    loveText=this.add.text(20,50,'❤️ '+love,{font:'24px sans-serif',fill:'#fff'}).setDepth(1);
     versionText=this.add.text(10,630,'v'+VERSION,{font:'12px sans-serif',fill:'#000'})
       .setOrigin(0,1).setDepth(1);
 
     // truck & girl
     const truck=this.add.image(520,245,'truck').setScale(0.924).setDepth(2);
-    const girl=this.add.image(520,210,'girl').setScale(0.5).setDepth(3)
+    const girl=this.add.image(520,220,'girl').setScale(0.5).setDepth(3)
       .setVisible(false);
 
     const intro=this.tweens.createTimeline({callbackScope:this,
       onComplete:()=>this.time.delayedCall(SPAWN_DELAY,spawnCustomer,[],this)});
-    intro.add({targets:[truck,girl],x:240,duration:800});
-    intro.add({targets:girl,y:292,duration:500,onStart:()=>girl.setVisible(true)});
+    intro.add({targets:[truck,girl],x:240,duration:600});
+    intro.add({targets:girl,y:292,duration:300,onStart:()=>girl.setVisible(true)});
     intro.play();
 
     // dialog
@@ -79,14 +79,14 @@ window.onload = function(){
       .setInteractive().setVisible(false).setDepth(12).on('pointerdown',()=>handleAction.call(this,'refuse'));
 
     // sliding report texts
-    reportLine1=this.add.text(480,moneyText.y,'',{font:'16px sans-serif',fill:'#000'})
-      .setOrigin(0,0.5).setVisible(false).setDepth(11);
-    reportLine2=this.add.text(480,moneyText.y+20,'',{font:'16px sans-serif',fill:'#000'})
-      .setOrigin(0,0.5).setVisible(false).setDepth(11);
-    reportLine3=this.add.text(480,loveText.y,'',{font:'16px sans-serif',fill:'#000'})
-      .setOrigin(0,0.5).setVisible(false).setDepth(11);
-    reportLine4=this.add.text(0,0,'',{font:'14px sans-serif',fill:'#000'})
-      .setVisible(false);
+    reportLine1=this.add.text(480,moneyText.y,'',{font:'16px sans-serif',fill:'#fff'})
+      .setOrigin(0,0.5).setVisible(false).setDepth(13);
+    reportLine2=this.add.text(480,moneyText.y+20,'',{font:'16px sans-serif',fill:'#fff'})
+      .setOrigin(0,0.5).setVisible(false).setDepth(13);
+    reportLine3=this.add.text(480,loveText.y,'',{font:'16px sans-serif',fill:'#fff'})
+      .setOrigin(0,0.5).setVisible(false).setDepth(13);
+    reportLine4=this.add.text(0,0,'',{font:'14px sans-serif',fill:'#fff'})
+      .setVisible(false).setDepth(13);
   }
 
   function spawnCustomer(){
@@ -160,20 +160,20 @@ window.onload = function(){
     };
 
     // animated report using timelines
-    const midX=240, midY=210;
+    const moneyX=160, loveX=320, midY=80;
 
     let pending=(type!=='refuse'?1:0)+(lD!==0?1:0);
     const done=()=>{ if(--pending<=0) finish(); };
 
     if(type!=='refuse'){
-      reportLine1.setStyle({fill:'#000'})
+      reportLine1.setStyle({fill:'#fff'})
         .setText(`$${cost.toFixed(2)}`)
         .setPosition(customer.x,customer.y).setVisible(true);
-      reportLine2.setText(`Tip ${tipPct}%`)
-        .setStyle({fontSize:'14px',fill:'#000'})
+      reportLine2.setText(`${tipPct}% TIP`)
+        .setStyle({fontSize:'14px',fill:'#ddf'})
         .setPosition(customer.x,customer.y+18).setVisible(true);
       reportLine3.setText(`$${tip.toFixed(2)}`)
-        .setStyle({fontSize:'16px',fill:'#000'})
+        .setStyle({fontSize:'16px',fill:'#fff'})
         .setPosition(customer.x,customer.y+36).setVisible(true);
 
       const tl=this.tweens.createTimeline({callbackScope:this,onComplete:()=>{
@@ -184,12 +184,12 @@ window.onload = function(){
           moneyText.setText('🪙 '+money.toFixed(2));
           done();
       }});
-      tl.add({targets:reportLine1,x:midX,y:midY,duration:500,completeDelay:1000,onComplete:()=>{
-            reportLine1.setText(`Paid $${cost.toFixed(2)}`).setColor('#008000');
+      tl.add({targets:reportLine1,x:moneyX,y:midY,duration:300,completeDelay:300,onComplete:()=>{
+            reportLine1.setText(`$${cost.toFixed(2)} PAID`).setColor('#8f8');
         }});
-      tl.add({targets:reportLine2,x:midX,y:midY+18,duration:500,completeDelay:1000},0);
-      tl.add({targets:reportLine3,x:midX,y:midY+36,duration:500,completeDelay:1000},0);
-      tl.add({targets:[reportLine1,reportLine2,reportLine3],x:moneyText.x,y:moneyText.y,alpha:0,duration:600});
+      tl.add({targets:reportLine2,x:moneyX,y:midY+18,duration:300,completeDelay:300},0);
+      tl.add({targets:reportLine3,x:moneyX,y:midY+36,duration:300,completeDelay:300},0);
+      tl.add({targets:[reportLine1,reportLine2,reportLine3],x:moneyText.x,y:moneyText.y,alpha:0,duration:400});
       tl.play();
     }
 
@@ -202,8 +202,8 @@ window.onload = function(){
           loveText.setText('❤️ '+love);
           done();
       }});
-      tl2.add({targets:reportLine4,x:midX,y:midY,duration:500,completeDelay:1000});
-      tl2.add({targets:reportLine4,x:loveText.x,y:loveText.y,alpha:0,duration:600});
+      tl2.add({targets:reportLine4,x:loveX,y:midY,duration:300,completeDelay:300});
+      tl2.add({targets:reportLine4,x:loveText.x,y:loveText.y,alpha:0,duration:400});
       tl2.play();
     }
     if(pending===0) finish();


### PR DESCRIPTION
## Summary
- adjust HUD font style and color
- speed up and reposition intro
- raise money and emoji score animations and separate left/right
- adjust timeline text formatting

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b3c6d6978832f9b9d4006e4b123de