### PR TITLE
Add adjustable game speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,18 +16,21 @@
 window.onload = function(){
   const COFFEE_COST=5.00, WATER_COST=5.58;
   const VERSION='54';
-  const SPAWN_DELAY=500;
+  const SPAWN_DELAY=300;
   const QUEUE_SPACING=70;
   const MAX_M=100, MAX_L=100;
+  let speed=1;
   let money=10.00, love=10, gameOver=false, customerQueue=[], coins=0, req='coffee';
   const keys=[];
+
+  const dur=v=>v/speed;
 
   const config={ type:Phaser.AUTO, parent:'game-container', backgroundColor:'#f2e5d7',
     scale:{ mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, width:480, height:640 },
     pixelArt:true, scene:{ preload, create } };
   new Phaser.Game(config);
 
-  let moneyText, loveText, versionText;
+  let moneyText, loveText, versionText, speedBtn;
   let dialogBg, dialogText, dialogCoins, btnSell, btnGive, btnRef;
   let reportLine1, reportLine2, reportLine3, reportLine4;
 
@@ -52,6 +55,9 @@ window.onload = function(){
     loveText=this.add.text(20,50,'❤️ '+love,{font:'20px sans-serif',fill:'#000'}).setDepth(1);
     versionText=this.add.text(10,630,'v'+VERSION,{font:'12px sans-serif',fill:'#000'})
       .setOrigin(0,1).setDepth(1);
+    speedBtn=this.add.text(460,20,'1x',{font:'20px sans-serif',fill:'#000',backgroundColor:'#ddd',padding:{x:6,y:4}})
+      .setOrigin(1,0).setDepth(1).setInteractive()
+      .on('pointerdown',()=>{ speed++; speedBtn.setText(speed+'x'); });
 
     // truck & girl
     const truck=this.add.image(520,245,'truck').setScale(0.924).setDepth(2);
@@ -59,9 +65,9 @@ window.onload = function(){
       .setVisible(false);
 
     const intro=this.tweens.createTimeline({callbackScope:this,
-      onComplete:()=>this.time.delayedCall(SPAWN_DELAY,spawnCustomer,[],this)});
-    intro.add({targets:[truck,girl],x:240,duration:800});
-    intro.add({targets:girl,y:292,duration:500,onStart:()=>girl.setVisible(true)});
+      onComplete:()=>this.time.delayedCall(dur(SPAWN_DELAY),spawnCustomer,[],this)});
+    intro.add({targets:[truck,girl],x:240,duration:dur(800)});
+    intro.add({targets:girl,y:292,duration:dur(500),onStart:()=>girl.setVisible(true)});
     intro.play();
 
     // dialog
@@ -99,7 +105,7 @@ window.onload = function(){
     c.sprite=this.add.sprite(240,startY,k).setScale(0.7).setDepth(4);
     const targetY=332+QUEUE_SPACING*customerQueue.length;
     customerQueue.push(c);
-    this.tweens.add({targets:c.sprite,y:targetY,duration:800,callbackScope:this,
+    this.tweens.add({targets:c.sprite,y:targetY,duration:dur(800),callbackScope:this,
       onComplete:()=>{ if(customerQueue[0]===c) { coins=c.coins; req=c.req; showDialog.call(this); } }});
   }
 
@@ -140,7 +146,7 @@ window.onload = function(){
     const customer=current.sprite;
     customerQueue.shift();
     const finish=()=>{
-      this.tweens.add({ targets: current.sprite, x: (type==='refuse'? -50:520), duration:600, callbackScope:this,
+      this.tweens.add({ targets: current.sprite, x: (type==='refuse'? -50:520), duration:dur(600), callbackScope:this,
         onComplete:()=>{
           current.sprite.destroy();
           if(money<=0){showEnd.call(this,'Game Over\nYou are fired');return;}
@@ -148,12 +154,12 @@ window.onload = function(){
           if(money>=MAX_M){showEnd.call(this,'Congrats! 💰');return;}
           if(love>=MAX_L){showEnd.call(this,'Victory! ❤️');return;}
           Phaser.Actions.Call(customerQueue,(c,idx)=>{
-            this.tweens.add({targets:c.sprite,y:332+QUEUE_SPACING*idx,duration:500});
+            this.tweens.add({targets:c.sprite,y:332+QUEUE_SPACING*idx,duration:dur(500)});
           });
           if(customerQueue.length>0){
-            this.time.delayedCall(600,showDialog,[],this);
+            this.time.delayedCall(dur(600),showDialog,[],this);
           }else{
-            this.time.delayedCall(SPAWN_DELAY, spawnCustomer, [], this);
+            this.time.delayedCall(dur(SPAWN_DELAY), spawnCustomer, [], this);
           }
         }
       });
@@ -184,12 +190,12 @@ window.onload = function(){
           moneyText.setText('🪙 '+money.toFixed(2));
           done();
       }});
-      tl.add({targets:reportLine1,x:midX,y:midY,duration:300,completeDelay:300,onComplete:()=>{
+      tl.add({targets:reportLine1,x:midX,y:midY,duration:dur(300),completeDelay:dur(300),onComplete:()=>{
             reportLine1.setText(`Paid $${cost.toFixed(2)}`).setColor('#8f8');
         }});
-      tl.add({targets:reportLine2,x:midX,y:midY+18,duration:300,completeDelay:300},0);
-      tl.add({targets:reportLine3,x:midX,y:midY+36,duration:300,completeDelay:300},0);
-      tl.add({targets:[reportLine1,reportLine2,reportLine3],x:moneyText.x,y:moneyText.y,alpha:0,duration:400});
+      tl.add({targets:reportLine2,x:midX,y:midY+18,duration:dur(300),completeDelay:dur(300)},0);
+      tl.add({targets:reportLine3,x:midX,y:midY+36,duration:dur(300),completeDelay:dur(300)},0);
+      tl.add({targets:[reportLine1,reportLine2,reportLine3],x:moneyText.x,y:moneyText.y,alpha:0,duration:dur(400)});
       tl.play();
     }
 
@@ -202,8 +208,8 @@ window.onload = function(){
           loveText.setText('❤️ '+love);
           done();
       }});
-      tl2.add({targets:reportLine4,x:midX,y:midY,duration:300,completeDelay:300});
-      tl2.add({targets:reportLine4,x:loveText.x,y:loveText.y,alpha:0,duration:400});
+      tl2.add({targets:reportLine4,x:midX,y:midY,duration:dur(300),completeDelay:dur(300)});
+      tl2.add({targets:reportLine4,x:loveText.x,y:loveText.y,alpha:0,duration:dur(400)});
       tl2.play();
     }
     if(pending===0) finish();
@@ -230,7 +236,7 @@ window.onload = function(){
     Phaser.Actions.Call(customerQueue,c=>c.sprite.destroy());
     customerQueue=[];
     gameOver=false;
-    this.time.delayedCall(SPAWN_DELAY, spawnCustomer, [], this);
+    this.time.delayedCall(dur(SPAWN_DELAY), spawnCustomer, [], this);
   }
 
 };


### PR DESCRIPTION
## Summary
- speed up customer spawn with a shorter base delay
- add a speed button that increments the speed multiplier
- apply multiplier to intro and gameplay animations

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b4010f124832f8073f2bb55cd3a46