### PR TITLE
Improve reaction animations

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,8 +37,8 @@ window.onload = function(){
     bg.setDisplaySize(this.scale.width,this.scale.height);
 
     // HUD
-    moneyText=this.add.text(20,20,'🪙 '+money.toFixed(2),{font:'20px sans-serif',fill:'#000'}).setDepth(1);
-    loveText=this.add.text(20,50,'❤️ '+love,{font:'20px sans-serif',fill:'#000'}).setDepth(1);
+    moneyText=this.add.text(20,20,'🪙 '+money.toFixed(2),{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
+    loveText=this.add.text(20,50,'❤️ '+love,{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
     versionText=this.add.text(10,630,'v'+VERSION,{font:'12px sans-serif',fill:'#000'})
       .setOrigin(0,1).setDepth(1);
     speedBtn=this.add.text(460,20,'1x',{font:'20px sans-serif',fill:'#000',backgroundColor:'#ddd',padding:{x:6,y:4}})
@@ -47,13 +47,13 @@ window.onload = function(){
 
     // truck & girl
     const truck=this.add.image(520,245,'truck').setScale(0.924).setDepth(2);
-    const girl=this.add.image(520,210,'girl').setScale(0.5).setDepth(3)
+    const girl=this.add.image(520,230,'girl').setScale(0.5).setDepth(3)
       .setVisible(false);
 
     const intro=this.tweens.createTimeline({callbackScope:this,
       onComplete:()=>this.time.delayedCall(dur(SPAWN_DELAY),spawnCustomer,[],this)});
-    intro.add({targets:[truck,girl],x:240,duration:dur(800)});
-    intro.add({targets:girl,y:292,duration:dur(500),onStart:()=>girl.setVisible(true)});
+    intro.add({targets:[truck,girl],x:240,duration:dur(600)});
+    intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)});
     intro.play();
 
     // dialog
@@ -64,19 +64,22 @@ window.onload = function(){
 
     // buttons
     btnSell=this.add.text(80,500,'Sell',{font:'18px sans-serif',fill:'#fff',backgroundColor:'#006400',padding:{x:12,y:6}})
-      .setInteractive().setVisible(false).setDepth(12).on('pointerdown',()=>handleAction.call(this,'sell'));
+      .setInteractive().setVisible(false).setDepth(12).setShadow(0,0,'#000',2,true,true)
+      .on('pointerdown',()=>handleAction.call(this,'sell'));
     btnGive=this.add.text(200,500,'Give Free',{font:'18px sans-serif',fill:'#fff',backgroundColor:'#008000',padding:{x:12,y:6}})
-      .setInteractive().setVisible(false).setDepth(12).on('pointerdown',()=>handleAction.call(this,'give'));
+      .setInteractive().setVisible(false).setDepth(12).setShadow(0,0,'#000',2,true,true)
+      .on('pointerdown',()=>handleAction.call(this,'give'));
     btnRef=this.add.text(360,500,'Refuse',{font:'18px sans-serif',fill:'#fff',backgroundColor:'#800000',padding:{x:12,y:6}})
-      .setInteractive().setVisible(false).setDepth(12).on('pointerdown',()=>handleAction.call(this,'refuse'));
+      .setInteractive().setVisible(false).setDepth(12).setShadow(0,0,'#000',2,true,true)
+      .on('pointerdown',()=>handleAction.call(this,'refuse'));
 
     // emoji icons behind buttons
     iconSell=this.add.text(0,0,'💵',{font:'60px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setAlpha(0.3).setDepth(11).setVisible(false);
+      .setOrigin(0.5).setAlpha(0.3).setDepth(13).setVisible(false);
     iconGive=this.add.text(0,0,'💝',{font:'60px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setAlpha(0.3).setDepth(11).setVisible(false);
+      .setOrigin(0.5).setAlpha(0.3).setDepth(13).setVisible(false);
     iconRef=this.add.text(0,0,'✋',{font:'60px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setAlpha(0.3).setDepth(11).setVisible(false);
+      .setOrigin(0.5).setAlpha(0.3).setDepth(13).setVisible(false);
 
     // position icons behind their buttons
     const centerPos=(btn)=>[btn.x+btn.width/2, btn.y+btn.height/2];
@@ -177,16 +180,23 @@ window.onload = function(){
     const done=()=>{ if(--pending<=0) finish(); };
 
     if(type!=='refuse'){
+      const showTip=tip>0;
       reportLine1.setStyle({fill:'#fff'})
         .setText(`$${cost.toFixed(2)}`)
         .setPosition(customer.x,customer.y).setVisible(true);
-      reportLine2.setText(`Tip ${tipPct}%`)
-        .setStyle({fontSize:'14px',fill:'#ddf'})
-        .setPosition(customer.x,customer.y+18).setVisible(true);
-      reportLine3.setText(`$${tip.toFixed(2)}`)
-        .setStyle({fontSize:'16px',fill:'#fff'})
-        .setPosition(customer.x,customer.y+36).setVisible(true);
+      if(showTip){
+        reportLine2.setText(`Tip ${tipPct}%`)
+          .setStyle({fontSize:'14px',fill:'#ddf'})
+          .setPosition(customer.x,customer.y+18).setVisible(true);
+        reportLine3.setText(`$${tip.toFixed(2)}`)
+          .setStyle({fontSize:'16px',fill:'#fff'})
+          .setPosition(customer.x,customer.y+36).setVisible(true);
+      }else{
+        reportLine2.setVisible(false).alpha=1;
+        reportLine3.setVisible(false).alpha=1;
+      }
 
+      const moving=[reportLine1];
       const tl=this.tweens.createTimeline({callbackScope:this,onComplete:()=>{
           reportLine1.setVisible(false).alpha=1;
           reportLine2.setVisible(false).alpha=1;
@@ -196,28 +206,51 @@ window.onload = function(){
           done();
       }});
       tl.add({targets:reportLine1,x:midX,y:midY,duration:dur(300),completeDelay:dur(300),onComplete:()=>{
-            reportLine1.setText(`Paid $${cost.toFixed(2)}`).setColor('#8f8');
+            if(type==='give'){
+              reportLine1.setText(`$${cost.toFixed(2)} LOSS`).setColor('#f88');
+            }else{
+              reportLine1.setText(`$${cost.toFixed(2)} PAID`).setColor('#8f8');
+            }
         }});
-      tl.add({targets:reportLine2,x:midX,y:midY+18,duration:dur(300),completeDelay:dur(300)},0);
-      tl.add({targets:reportLine3,x:midX,y:midY+36,duration:dur(300),completeDelay:dur(300)},0);
-      tl.add({targets:[reportLine1,reportLine2,reportLine3],x:moneyText.x,y:moneyText.y,alpha:0,duration:dur(400)});
+      if(showTip){
+        tl.add({targets:reportLine2,x:midX,y:midY+18,duration:dur(300),completeDelay:dur(300)},0);
+        tl.add({targets:reportLine3,x:midX,y:midY+36,duration:dur(300),completeDelay:dur(300)},0);
+        moving.push(reportLine2,reportLine3);
+      }
+      tl.add({targets:moving,x:moneyText.x,y:moneyText.y,alpha:0,duration:dur(400)});
       tl.play();
     }
 
     if(lD!==0){
-      reportLine4.setText(lD>0?'❤️'.repeat(lD):'😠'.repeat(-lD))
-        .setPosition(customer.x,customer.y).setVisible(true);
-      const tl2=this.tweens.createTimeline({callbackScope:this,onComplete:()=>{
-          reportLine4.setVisible(false).alpha=1;
-          love+=lD;
-          loveText.setText('❤️ '+love);
-          done();
-      }});
-      tl2.add({targets:reportLine4,x:midX,y:midY,duration:dur(300),completeDelay:dur(300)});
-      tl2.add({targets:reportLine4,x:loveText.x,y:loveText.y,alpha:0,duration:dur(400)});
-      tl2.play();
+      animateLoveChange.call(this,lD,customer,done);
     }
     if(pending===0) finish();
+  }
+
+  function animateLoveChange(delta, customer, cb){
+    const count=Math.abs(delta);
+    const emoji=delta>0?'❤️':'😠';
+    const baseX=customer.x-80;
+    const baseY=customer.y+40;
+    const hearts=[];
+    for(let i=0;i<count;i++){
+      const h=this.add.text(customer.x,customer.y,emoji,{font:'24px sans-serif',fill:'#fff'})
+        .setOrigin(0.5).setDepth(11);
+      hearts.push(h);
+      this.tweens.add({targets:h,x:baseX+i*20,y:baseY,duration:dur(400),ease:'Cubic.easeOut'});
+    }
+    const popOne=(idx)=>{
+      if(idx>=hearts.length){ if(cb) cb(); return; }
+      const h=hearts[idx];
+      this.tweens.add({targets:h,x:loveText.x,y:loveText.y,scale:1.2,angle:360,alpha:0,
+        duration:dur(250),onComplete:()=>{
+          love+=delta>0?1:-1;
+          loveText.setText('❤️ '+love);
+          h.destroy();
+          popOne(idx+1);
+        }});
+    };
+    this.time.delayedCall(dur(400),()=>popOne(0),[],this);
   }
 
   function showEnd(msg){


### PR DESCRIPTION
## Summary
- spawn coffee girl slightly lower and faster
- bring option emojis to the front and blur button boxes
- append **PAID** to money report
- differentiate love score animation
- move hearts closer to customers and display **LOSS** when giving free
- hide zero tips and enlarge top-left scores

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684b48f74238832f84a719fe0acac924