### PR TITLE
Fix duplicate PAID text

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -215,9 +215,8 @@ window.onload = function(){
               reportLine1.setText(`$${cost.toFixed(2)} LOSS`).setColor('#f88');
             }else{
               reportLine1.setText(`$${cost.toFixed(2)} PAID`).setColor('#8f8');
-            }
 
-            reportLine1.setText(`$${cost.toFixed(2)} PAID`).setColor('#8f8');
+            }
 
         }});
       if(showTip){


### PR DESCRIPTION
## Summary
- remove redundant text assignment in payment tween

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684b4ddd8be4832fba7697e3f5b946a3