### PR TITLE
Update Puppeteer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ npm install
 npm test
 ```
 
+If you set `PUPPETEER_SKIP_DOWNLOAD=1` when running `npm install`, Puppeteer will not download its bundled browser. In that case, ensure Chrome or Chromium is installed locally and available on your `PATH` so `npm test` can launch it.
+
 This uses Puppeteer to launch the game in a headless browser and checks that all assets load without errors.
 
 ## License


### PR DESCRIPTION
## Summary
- explain the need for Chrome/Chromium if Puppeteer download is skipped

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684b4fa37e1c832f8021b8c2946263eb