### PR TITLE
Add font request to tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,17 @@ async function run() {
     });
   });
 
+  await new Promise(resolve => {
+    http.get('http://localhost:8080/assets/fonts/PressStart2P-Regular.ttf', res => {
+      if (res.statusCode !== 200) errors.push(`Font Status ${res.statusCode}`);
+      res.resume();
+      res.on('end', resolve);
+    }).on('error', err => {
+      errors.push(err.message);
+      resolve();
+    });
+  });
+
   server.kill();
 
   if (errors.length) {


### PR DESCRIPTION
## Summary
- extend test to request PressStart2P font asset and fail if missing

## Testing
- `npm test` *(fails: Font Status 404)*

------
https://chatgpt.com/codex/tasks/task_e_684b77e50878832fae515240d3cb855b