### PR TITLE
Remove Press Start font from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ Thumbs.db
 
 # Node modules
 node_modules/
+
+# Fonts
+assets/fonts/*.ttf
+


### PR DESCRIPTION
## Summary
- revert README font line
- delete `assets/fonts/PressStart2P-Regular.ttf`
- ignore `.ttf` fonts in `.gitignore`

## Testing
- `npm install`
- `npm test` *(fails: Font Status 404)*

------
https://chatgpt.com/codex/tasks/task_e_684b79317680832fbaa5d39340f7148c