### PR TITLE
Delay queue movement until fade-out completes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -381,10 +381,8 @@ window.onload = function(){
     const friend=current.friend;
     if(current.giveUpTimer){ current.giveUpTimer.remove(false); }
     customerQueue.shift();
-    
-    repositionQueue(this,false);
+
     const finish=()=>{
-      repositionQueue(this,false);
       const targets=[current.sprite];
       if(friend) targets.push(friend);
       targets.forEach(t=>t.setDepth(5));
@@ -396,6 +394,7 @@ window.onload = function(){
           if(love<=0){showEnd.call(this,'Game Over 😠');return;}
           if(money>=MAX_M){showEnd.call(this,'Congrats! 💰');return;}
           if(love>=MAX_L){showEnd.call(this,'Victory! ❤️');return;}
+            repositionQueue(this,false);
             repositionQueue(this);
             if(customerQueue.length>0){
               const next=customerQueue[0];


### PR DESCRIPTION
## Summary
- move repositionQueue call so the line advances only after the departing
  customer finishes fading out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684baf274718832f923669f7d775ce88