### PR TITLE
Fix flicker when customers join queue

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,7 @@ window.onload = function(){
 
   function repositionQueue(scene, join=true){
     Phaser.Actions.Call(customerQueue,(c,idx)=>{
+      if(c.approaching) return;
       const targetY=332+QUEUE_SPACING*idx;
       scene.tweens.add({targets:c.sprite,x:QUEUE_X,y:targetY,duration:dur(500)});
       if(c.friend){
@@ -74,6 +75,7 @@ window.onload = function(){
     const w=wanderers.splice(idx,1)[0];
     if(w.walkTween) w.walkTween.stop();
     const targetY=332+QUEUE_SPACING*customerQueue.length;
+    w.approaching = true;
     customerQueue.push(w);
     const dist=Phaser.Math.Distance.Between(w.sprite.x,w.sprite.y,QUEUE_X,targetY);
     w.sprite.setDepth(5);


### PR DESCRIPTION
## Summary
- avoid repositioning customers that are still walking to the line
- mark wanderers as `approaching` when they start walking to the queue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb47d8818832fa4346bee1ccd2d05