### PR TITLE
Fix restart intro and give dialog

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,8 @@ window.onload = function(){
   const FRIEND_OFFSET=40;
   const WANDER_Y=600;
   const MAX_WANDERERS=1;
+  const WALK_OFF_BASE=1000;
+  const WALK_OFF_SLOW=200;
   const MAX_M=100, MAX_L=100;
   const MAX_SPEED=3;
   let speed=1;
@@ -39,6 +41,7 @@ window.onload = function(){
   let iconSell, iconGive, iconRef;
   let reportLine1, reportLine2, reportLine3, reportLine4, tipText;
   let paidStamp, lossStamp;
+  let truck, girl;
 
   function calcLoveLevel(v){
     if(v>=100) return 4;
@@ -100,7 +103,8 @@ window.onload = function(){
     const targets=[c.sprite];
     if(c.friend) targets.push(c.friend);
     wanderers.splice(wanderers.indexOf(c),1);
-    scene.tweens.add({targets:targets,x:targetX,duration:dur(1000),onComplete:()=>{
+    const extra = customerQueue.length * WALK_OFF_SLOW;
+    scene.tweens.add({targets:targets,x:targetX,duration:dur(WALK_OFF_BASE+extra),onComplete:()=>{
         targets.forEach(t=>t.destroy());
     }});
   }
@@ -162,6 +166,17 @@ window.onload = function(){
     spawnTimer = scene.time.delayedCall(dur(delay), spawnCustomer, [], scene);
   }
 
+  function playIntro(scene){
+    if(!truck || !girl) return;
+    truck.setPosition(520,245);
+    girl.setPosition(520,260).setVisible(false);
+    const intro=scene.tweens.createTimeline({callbackScope:scene,
+      onComplete:()=>scheduleNextSpawn(scene)});
+    intro.add({targets:[truck,girl],x:240,duration:dur(600)});
+    intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)});
+    intro.play();
+  }
+
   function preload(){
     this.load.image('bg','assets/bg.png');
     this.load.image('truck','assets/truck.png');
@@ -199,15 +214,11 @@ window.onload = function(){
       });
 
     // truck & girl
-    const truck=this.add.image(520,245,'truck').setScale(0.924).setDepth(2);
+    truck=this.add.image(520,245,'truck').setScale(0.924).setDepth(2);
 
-    const girl=this.add.image(520,260,'girl').setScale(0.5).setDepth(3).setVisible(false);
+    girl=this.add.image(520,260,'girl').setScale(0.5).setDepth(3).setVisible(false);
 
-    const intro=this.tweens.createTimeline({callbackScope:this,
-      onComplete:()=>scheduleNextSpawn(this)});
-    intro.add({targets:[truck,girl],x:240,duration:dur(600)});
-    intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)});
-    intro.play();
+    playIntro(this);
 
     // dialog
     dialogBg=this.add.rectangle(240,460,460,120,0xffffff).setStrokeStyle(2,0x000).setVisible(false).setDepth(10);
@@ -369,7 +380,7 @@ window.onload = function(){
   }
 
   function handleAction(type){
-    clearDialog(type==='sell');
+    clearDialog(type!=='refuse');
     const current=customerQueue[0];
     const orderCount=current.orders.length;
     const totalCost=current.orders.reduce((s,o)=>s+(o.req==='coffee'?COFFEE_COST:WATER_COST)*o.qty,0);
@@ -609,7 +620,7 @@ window.onload = function(){
     speed = 1;
     if (speedBtn) speedBtn.setText('1x');
     gameOver=false;
-    scheduleNextSpawn(this);
+    playIntro(this);
   }
 
 };


### PR DESCRIPTION
## Summary
- restore intro animation when restarting the game
- keep dialog visible for Give Free choice
- slow down walk-away tween when queue is busy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb6e2fde4832fa7064e3936ac4109