### PR TITLE
Fix createOrder invocation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -307,7 +307,7 @@ window.onload = function(){
     const c={ orders:[] };
     const startScale=1.1;
     const k=Phaser.Utils.Array.GetRandom(keys);
-    const order=createOrder(0);
+    const order=createOrder();
     if(customerQueue.length>=maxQ){
       if(wanderers.length>=MAX_WANDERERS){
         scheduleNextSpawn(this);


### PR DESCRIPTION
## Summary
- remove unused argument from `createOrder()` call in `spawnCustomer`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bc4d42fd4832f9ffd1cb0ecd9d303