### PR TITLE
Remove font download step from test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ If the game fails to start, check your browser's console for errors.
 
 Have fun clicking!
 
-## Fonts
-
-The game uses the retro, pixel-style **Press Start 2P** typeface from Google Fonts.
-Download `PressStart2P-Regular.ttf` and place it in `assets/fonts/` so the game
-can load it correctly. The font license is provided in
-`assets/fonts/OFL.txt`.
-
 ## Running tests
 
 Install dependencies and run the automated check:

--- a/test/test.js
+++ b/test/test.js
@@ -1,18 +1,8 @@
-const { spawn, spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 const path = require('path');
-const fs = require('fs');
 const http = require('http');
 
 async function run() {
-  const fontPath = path.join(__dirname, '..', 'assets', 'fonts', 'PressStart2P-Regular.ttf');
-  if (!fs.existsSync(fontPath)) {
-    const url = 'https://raw.githubusercontent.com/google/fonts/main/ofl/pressstart2p/PressStart2P-Regular.ttf';
-    const res = spawnSync('curl', ['-L', '-o', fontPath, url]);
-    if (res.status !== 0) {
-      console.warn('Font download failed');
-    }
-  }
-
   const serverPath = path.join(__dirname, '..', 'node_modules', '.bin', 'http-server');
   const server = spawn(serverPath, ['-p', '8080', '-c-1'], { stdio: 'inherit' });
 


### PR DESCRIPTION
## Summary
- remove unused Press Start 2P font download from `test/test.js`
- update README to remove outdated font instructions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bc42a24f8832f99ca2900603c72f7