### PR TITLE
Delay hiding dialog after selling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -522,14 +522,14 @@ window.onload = function(){
       }else{
         t.setText(`$${totalCost.toFixed(2)}`);
       }
-      dialogBg.setVisible(false);
-      dialogText.setVisible(false);
-      p.setVisible(false);
       this.time.delayedCall(dur(1000),()=>{
         paidStamp.setVisible(false);
         tipText.setVisible(false);
         const tl=this.tweens.createTimeline({callbackScope:this,onComplete:()=>{
             t.setVisible(false);
+            dialogBg.setVisible(false);
+            dialogText.setVisible(false);
+            p.setVisible(false);
             money=+(money+mD).toFixed(2);
             moneyText.setText('🪙 '+receipt(money));
             done();


### PR DESCRIPTION
## Summary
- keep the sell dialog visible while the paid and tip amounts animate
- hide the dialog elements once the coin animation finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bcd3030a4832f831bb3d3783259f2