### PR TITLE
Fix disappearing customers at level 2

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -181,7 +181,11 @@ window.onload = function(){
         if(d<minDist){ closestIdx=i; minDist=d; }
       }
       const c=wanderers.splice(closestIdx,1)[0];
-      if(c.walkTween) c.walkTween.stop();
+      if(c.walkTween){
+        c.walkTween.stop();
+        c.walkTween.remove();
+        c.walkTween=null;
+      }
       const idx=queue.length;
       c.atOrder=false;
       queue.push(c);


### PR DESCRIPTION
## Summary
- stop and remove previous wanderer tweens when moving them into the queue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8aa14200832fbc4824cc19d1cc7d