### PR TITLE
Fix first customer freeze by preserving button hit areas

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -519,9 +519,11 @@ window.onload = function(){
       .setVisible(true);
     tipText.setVisible(false);
     btnSell.setVisible(canAfford);
-    if (canAfford) btnSell.setInteractive(); else btnSell.disableInteractive();
-    btnGive.setVisible(true).setInteractive();
-    btnRef.setVisible(true).setInteractive();
+    if (btnSell.input) btnSell.input.enabled = canAfford;
+    btnGive.setVisible(true);
+    if (btnGive.input) btnGive.input.enabled = true;
+    btnRef.setVisible(true);
+    if (btnRef.input) btnRef.input.enabled = true;
     iconSell.setVisible(canAfford); iconGive.setVisible(true); iconRef.setVisible(true);
   }
 
@@ -539,9 +541,12 @@ window.onload = function(){
       dialogPriceLabel.setVisible(true);
       dialogPriceValue.setVisible(true);
     }
-    btnSell.setVisible(false).disableInteractive();
-    btnGive.setVisible(false).disableInteractive();
-    btnRef.setVisible(false).disableInteractive();
+    btnSell.setVisible(false);
+    if (btnSell.input) btnSell.input.enabled = false;
+    btnGive.setVisible(false);
+    if (btnGive.input) btnGive.input.enabled = false;
+    btnRef.setVisible(false);
+    if (btnRef.input) btnRef.input.enabled = false;
     iconSell.setVisible(false); iconGive.setVisible(false); iconRef.setVisible(false);
     tipText.setVisible(false);
   }


### PR DESCRIPTION
## Summary
- disable/enable button input using the `input.enabled` flag
- avoid calling `setInteractive()` again which reset button hit areas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8c527490832fb5fff8b08c313d67