### PR TITLE
Fix button blink to reuse hit area

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -135,7 +135,7 @@ window.onload = function(){
       duration: dur(80),
       repeat: 1,
       onComplete: () => {
-        btn.setInteractive();
+        if (btn.input) btn.input.enabled = true;  // restore interactivity
         if (onComplete) onComplete();
       }
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,32 @@
 const { spawn } = require('child_process');
 const path = require('path');
 const http = require('http');
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+function testBlinkButton() {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf8');
+  const match = /function blinkButton\(btn, onComplete\)[\s\S]*?\n\s*\}\);\n\s*\}/.exec(code);
+  if (!match) throw new Error('blinkButton not found');
+  const context = {};
+  vm.createContext(context);
+  context.blinkBtn = null;
+  vm.runInContext('const dur=v=>v;\n' + match[0] + '\nblinkBtn=blinkButton;', context);
+  const blinkButton = context.blinkBtn;
+  let disableCalled = false;
+  const btn = {
+    input: { enabled: true },
+    disableInteractive() { disableCalled = true; this.input.enabled = false; },
+    setInteractive() { this.setInteractiveCalled = true; this.input.enabled = true; }
+  };
+  const scene = { tweens: { add(cfg) { if (cfg.onComplete) cfg.onComplete(); return {}; } } };
+  blinkButton.call(scene, btn);
+  assert(disableCalled, 'disableInteractive not called');
+  assert.strictEqual(btn.input.enabled, true, 'button not re-enabled');
+  assert.ok(!btn.setInteractiveCalled, 'setInteractive should not be called');
+  console.log('blinkButton interactivity test passed');
+}
 
 async function run() {
   const serverPath = path.join(__dirname, '..', 'node_modules', '.bin', 'http-server');
@@ -28,6 +54,7 @@ async function run() {
     process.exit(1);
   } else {
     console.log('Game loaded without errors');
+    testBlinkButton();
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure blinkButton re-enables existing hit area instead of resetting interactivity
- add unit test verifying the button remains interactive after blinking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c926d8360832fb2afcd7d24be2ee7