### PR TITLE
Improve test section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ Customers can now order any of the following drinks:
 
 ## Running tests
 
-Install dependencies and run the automated check:
+Before running the tests, install all dependencies:
 
 ```bash
 npm install
-npm test
 ```
 
-The test script starts a local server and verifies the page responds without errors.
+Then run the automated check. `npm test` relies on `node_modules/.bin/http-server` to start a local server and verify the page responds without errors:
+
+```bash
+npm test
+```
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify the need to install dependencies before running tests
- note that `npm test` uses `node_modules/.bin/http-server`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9d3a9418832fbff385691f9a1091