### PR TITLE
Fix intro delay, add freeze troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ If the game fails to start, check your browser's console for errors.
 
 Have fun clicking!
 
+## Troubleshooting
+
+If the truck never drives in at the start or the page seems frozen,
+verify that you're running the game through a local web server.
+Opening `index.html` directly from the filesystem prevents asset files
+from loading, which stops the game before it begins. Start a server
+with `npm start` or `python3 -m http.server` and load
+`http://localhost:8080` instead.
+
 ## Controls
 
 When you choose to sell or give a drink, the button briefly blinks.

--- a/src/main.js
+++ b/src/main.js
@@ -415,7 +415,8 @@ window.onload = function(){
     lossStamp=this.add.text(0,0,'LOSS',{font:'24px sans-serif',fill:'#a00'})
       .setOrigin(0.5).setDepth(12).setVisible(false);
 
-    playIntro(this);
+    // defer intro slightly so scene objects are fully ready
+    this.time.delayedCall(dur(10), () => playIntro(this));
   }
 
   function spawnCustomer(){


### PR DESCRIPTION
## Summary
- defer intro start slightly so scene is fully ready
- mention troubleshooting steps in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9fcab8c4832fa61b0faa5e9e4b98