### PR TITLE
Improve local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ Coffee Clicker is a small browser game built with [Phaser](https://phaser.io/). 
 
    Then navigate to `http://localhost:8000` in your browser.
 
-   The game must be accessed via `http://` either locally or on any static host. Opening `index.html` directly will not load all assets correctly. Fonts and images are served from the `assets` directory, so either `python3 -m http.server` or `npm start` must be running for them to load.
+   The game must be accessed via `http://` either locally or on any static host.
+   If you open `index.html` directly using the `file://` protocol the game will
+   appear frozen because assets cannot be loaded. The page now detects this case
+   and shows a message with instructions. Run `python3 -m http.server` (or
+   `npm start`) from the repository root and open
+   [http://localhost:8000](http://localhost:8000) to play.
 
 The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by default. If you prefer the CDN version, replace the script tag in `index.html` with:
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,20 @@
 </head>
 <body>
   <div id="game-container"></div>
-  <script src="src/main.js"></script>
+  <script>
+    if (location.protocol === 'file:') {
+      document.body.innerHTML =
+        '<div style="padding:20px;font-family:sans-serif">' +
+        '<h2>Coffee Clicker</h2>' +
+        '<p>This game must be served over HTTP for assets to load.</p>' +
+        '<p>Run <code>python3 -m http.server</code> in the repo root ' +
+        'and open <a href="http://localhost:8000">http://localhost:8000</a>.</p>' +
+        '</div>';
+    } else {
+      var s=document.createElement('script');
+      s.src='src/main.js';
+      document.body.appendChild(s);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a helpful message when the game is opened via `file://`
- clarify README instructions about running a local HTTP server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca40f1f9c832f82596f418ab0b01c