### PR TITLE
Fix README port instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Coffee Clicker is a small browser game built with [Phaser](https://phaser.io/). 
    The game must be accessed via `http://` either locally or on any static host.
    If you open `index.html` directly using the `file://` protocol the game will
    appear frozen because assets cannot be loaded. The page now detects this case
-   and shows a message with instructions. Run `python3 -m http.server` (or
-   `npm start`) from the repository root and open
-   [http://localhost:8000](http://localhost:8000) to play.
+   and shows a message with instructions. Run `python3 -m http.server` from the
+   repository root and open [http://localhost:8000](http://localhost:8000) to
+   play. If you prefer `npm start`, it will serve the game on port `8080`, so
+   open [http://localhost:8080](http://localhost:8080) instead.
 
 The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by default. If you prefer the CDN version, replace the script tag in `index.html` with:
 


### PR DESCRIPTION
## Summary
- clarify that `npm start` runs on port `8080`
- keep instructions for `python3 -m http.server` using port `8000`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca988a90c832f956d086f9dd471d9