### PR TITLE
Fix game initialization timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
-window.onload = function(){
+(() => {
+  function init(){
   // full drink menu with prices
   const MENU=[
     {name:"Lady Roaster Drip", price:3.90},
@@ -1027,4 +1028,11 @@ window.onload = function(){
     playIntro(this);
   }
 
-};
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    init();
+  } else {
+    window.addEventListener('load', init);
+  }
+})();


### PR DESCRIPTION
## Summary
- guard game startup with a `load` listener
- convert `window.onload` block into an IIFE that calls the `init` function once the page is ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cad80db0c832fa18a8c8f1f42aa0e