### PR TITLE
Fix intro timing to avoid startup freeze

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -430,8 +430,8 @@
     lossStamp=this.add.text(0,0,'LOSS',{font:'24px sans-serif',fill:'#a00'})
       .setOrigin(0.5).setDepth(12).setVisible(false);
 
-    // defer intro slightly so scene objects are fully ready
-    this.time.delayedCall(dur(10), () => playIntro(this));
+    // start intro after the first update tick to ensure assets are ready
+    this.events.once('update', () => playIntro(this));
   }
 
   function spawnCustomer(){


### PR DESCRIPTION
## Summary
- delay intro animation until the first update tick

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb12506d4832f8e267f561fa8b71c