### PR TITLE
Fix intro timing after assets load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -330,6 +330,12 @@
     loader.on('loaderror', file=>{
       console.error('Asset failed to load:', file.key || file.src);
     });
+    loader.once('complete', () => {
+      // intro runs after the scene's create method, ensuring all
+      // game objects exist before we animate the truck.
+      this.events.once('create', () =>
+        this.time.delayedCall(dur(10), () => playIntro(this)));
+    });
     loader.image('bg','assets/bg.png');
     loader.image('truck','assets/truck.png');
     loader.image('girl','assets/coffeegirl.png');
@@ -429,9 +435,6 @@
       .setOrigin(0.5).setDepth(12).setVisible(false);
     lossStamp=this.add.text(0,0,'LOSS',{font:'24px sans-serif',fill:'#a00'})
       .setOrigin(0.5).setDepth(12).setVisible(false);
-
-    // defer intro slightly so scene objects are fully ready
-    this.time.delayedCall(dur(10), () => playIntro(this));
   }
 
   function spawnCustomer(){


### PR DESCRIPTION
## Summary
- run the intro only after all assets have loaded and the scene is created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb12506d4832f8e267f561fa8b71c