### PR TITLE
Call intro directly

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -312,6 +312,7 @@
   }
 
   function playIntro(scene){
+    scene = scene || this;
     if(!truck || !girl) return;
     truck.setPosition(520,245);
     girl.setPosition(520,260).setVisible(false);
@@ -431,7 +432,7 @@
       .setOrigin(0.5).setDepth(12).setVisible(false);
 
     // start intro after assets are ready
-    this.time.delayedCall(0, () => playIntro(this));
+    playIntro.call(this);
   }
 
   function spawnCustomer(){


### PR DESCRIPTION
## Summary
- play the intro without a delayed call in `create()`
- allow `playIntro` to use `this` if no scene arg is given

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc7590c54832f980f838ce5c5f80e