### PR TITLE
Handle missing assets

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -352,6 +352,10 @@
       console.error(msg);
       this.add.text(240,320,msg,{font:'16px sans-serif',fill:'#f00',align:'center',wordWrap:{width:460}})
         .setOrigin(0.5).setDepth(30);
+      this.add.text(240,360,'Retry Loading',{font:'20px sans-serif',fill:'#00f'})
+        .setOrigin(0.5).setDepth(30).setInteractive({useHandCursor:true})
+        .on('pointerdown',()=>window.location.reload());
+      return;
     }
     // background
     let bg=this.add.image(0,0,'bg').setOrigin(0).setDepth(0);


### PR DESCRIPTION
## Summary
- show a visible error message when required assets fail to load
- skip the intro when assets are missing
- provide a 'Retry Loading' option

## Testing
- `npm test`
- removed `assets/truck.png` and ran a Puppeteer check to confirm the console message was shown

------
https://chatgpt.com/codex/tasks/task_e_684cc74fcad4832f9e7c08e4d80446bd