### PR TITLE
Add console logs and standard script loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Coffee Clicker is a small browser game built with [Phaser](https://phaser.io/). 
 
    Then navigate to `http://localhost:8000` in your browser.
 
+   The game now loads `src/main.js` with a standard `<script src="src/main.js" defer></script>` tag
+   in `index.html`. If the page stays blank, open the browser console and look for
+   messages about missing assets.
+
 
 
 The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by default. If you prefer the CDN version, replace the script tag in `index.html` with:

--- a/index.html
+++ b/index.html
@@ -23,11 +23,8 @@
         '<p>Run <code>python3 -m http.server</code> in the repo root ' +
         'and open <a href="http://localhost:8000">http://localhost:8000</a>.</p>' +
         '</div>';
-    } else {
-      var s=document.createElement('script');
-      s.src='src/main.js';
-      document.body.appendChild(s);
     }
   </script>
+  <script src="src/main.js" defer></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,9 @@
 (() => {
+  console.log('main.js loaded');
+  let initCalled = false;
   function init(){
+    console.log('init() executing');
+    initCalled = true;
   // full drink menu with prices
   const MENU=[
     {name:"Lady Roaster Drip", price:3.90},
@@ -312,7 +316,11 @@
   }
 
   function playIntro(scene){
-    if(!truck || !girl) return;
+    if(!truck || !girl) {
+      console.warn('playIntro skipped: missing truck or girl');
+      return;
+    }
+    console.log('playIntro starting');
     truck.setPosition(520,245);
     girl.setPosition(520,260).setVisible(false);
     const intro=scene.tweens.createTimeline({callbackScope:scene,
@@ -1048,5 +1056,10 @@
     init();
   } else {
     window.addEventListener('load', init);
+    setTimeout(() => {
+      if (!initCalled) {
+        console.error('init() did not execute');
+      }
+    }, 3000);
   }
 })();


### PR DESCRIPTION
## Summary
- log when main script loads and when `init()` runs
- warn if `init()` fails to execute
- log start of `playIntro` and warn if required assets are missing
- use a normal `<script>` tag in *index.html*
- mention new script tag in README and advise checking console for missing assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc7da1d30832f869af916f5fe9039