### PR TITLE
Update server instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Coffee Clicker is a small browser game built with [Phaser](https://phaser.io/). 
 
 ## Getting Started
 
-1. From the repository root, run a simple local HTTP server:
+1. From the repository root, start the local development server:
 
    ```bash
-   python3 -m http.server
+   npm install
+   npm start
    ```
 
-   Then navigate to `http://localhost:8000` in your browser.
+   This runs `http-server` on `http://localhost:8080`. Open that URL in your browser.
 
    Click **Start Shift** when it appears to begin the game.
 


### PR DESCRIPTION
## Summary
- clarify dev server usage: `npm start` serves at http://localhost:8080

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ccd5d2ca0832f8cbf29be583a09f6