### PR TITLE
Add pretest script to ensure dependencies before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Coffee Clicker game",
   "scripts": {
     "start": "http-server -p 8080 -c-1",
+    "pretest": "npm install",
     "test": "node test/test.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- ensure `npm install` runs before tests by adding a `pretest` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd4001368832fa384785163e0c858