### PR TITLE
Fix button reactivation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -140,7 +140,7 @@
       duration: dur(80),
       repeat: 1,
       onComplete: () => {
-        if (btn.input) btn.input.enabled = true;  // restore interactivity
+        if (btn.setInteractive) btn.setInteractive();
         if (onComplete) onComplete();
       }
     });

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ function testBlinkButton() {
   blinkButton.call(scene, btn);
   assert(disableCalled, 'disableInteractive not called');
   assert.strictEqual(btn.input.enabled, true, 'button not re-enabled');
-  assert.ok(!btn.setInteractiveCalled, 'setInteractive should not be called');
+  assert.ok(btn.setInteractiveCalled, 'setInteractive should be called to re-enable');
   console.log('blinkButton interactivity test passed');
 }
 


### PR DESCRIPTION
## Summary
- restore button interactivity using `setInteractive()`
- expect `setInteractive` call in blinkButton unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd6f042bc832fbb02e34964de9173