### PR TITLE
Refactor init into modular pieces

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,8 @@
   function init(){
     console.log('init() executing');
     initCalled = true;
+    new Phaser.Game(config);
+  }
   // full drink menu with prices
   const MENU=[
     {name:"Lady Roaster Drip", price:3.90},
@@ -146,10 +148,6 @@
     });
   }
 
-  const config={ type:Phaser.AUTO, parent:'game-container', backgroundColor:'#f2e5d7',
-    scale:{ mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, width:480, height:640 },
-    pixelArt:true, scene:{ preload, create } };
-  new Phaser.Game(config);
 
   let moneyText, loveText, queueLevelText;
   let dialogBg, dialogText, dialogCoins, dialogPriceLabel, dialogPriceValue,
@@ -369,6 +367,8 @@
   }
 
   function create(){
+    this.assets = Assets;
+    this.customers = Customers;
     const missing=requiredAssets.filter(key=>!this.textures.exists(key));
     if(missing.length){
       const msg='Missing assets: '+missing.join(', ');
@@ -1054,7 +1054,15 @@
     showStartScreen.call(this);
   }
 
-  }
+  const Assets = { keys, requiredAssets, preload };
+  const Scene = { create, showStartScreen, playIntro };
+  const Customers = { spawnCustomer, lureNextWanderer, moveQueueForward, scheduleNextSpawn,
+                      showDialog, clearDialog, handleAction, showFalconAttack,
+                      showCustomerRevolt, restartGame };
+
+  const config={ type:Phaser.AUTO, parent:'game-container', backgroundColor:'#f2e5d7',
+    scale:{ mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, width:480, height:640 },
+    pixelArt:true, scene:{ preload: Assets.preload, create: Scene.create } };
 
   if (document.readyState === 'complete' || document.readyState === 'interactive') {
     init();


### PR DESCRIPTION
## Summary
- extract config setup from `init` to top-level objects
- expose customer and asset modules on the Phaser scene
- keep main entry small and clear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd70023f4832fb2a2995dd22160f1