### PR TITLE
Adjust button layout and update tests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -153,7 +153,6 @@
   let moneyText, loveText, queueLevelText;
   let dialogBg, dialogText, dialogCoins, dialogPriceLabel, dialogPriceValue,
       btnSell, btnGive, btnRef;
-  let iconSell, iconGive, iconRef;
   let reportLine1, reportLine2, reportLine3, reportLine4, tipText;
   let paidStamp, lossStamp;
   let truck, girl;
@@ -431,7 +430,7 @@
       .setOrigin(0.5).setVisible(false).setDepth(11);
 
     // helper to create a rounded rectangle button with consistent sizing
-    const createButton=(x,label,color,handler)=>{
+    const createButton=(x,label,iconChar,iconSize,color,handler)=>{
       const width=120, height=40, radius=8;
       const g=this.add.graphics();
       // Graphics objects do not support setShadow. Draw a simple shadow
@@ -441,9 +440,12 @@
 
       g.fillStyle(color,1);
       g.fillRoundedRect(-width/2,-height/2,width,height,radius);
-      const t=this.add.text(0,0,label,{font:'20px sans-serif',fill:'#fff'}).setOrigin(0.5);
+      const t=this.add.text(-width/2+10,0,label,{font:'20px sans-serif',fill:'#fff'})
+        .setOrigin(0,0.5);
+      const icon=this.add.text(width/2-10,0,iconChar,{font:`${iconSize}px sans-serif`,fill:'#fff'})
+        .setOrigin(1,0.5);
       // position the button slightly lower so it peeks out of the dialog box
-      const c=this.add.container(x,520,[g,t])
+      const c=this.add.container(x,520,[g,t,icon])
         .setSize(width,height)
         .setDepth(12)
         .setVisible(false);
@@ -453,17 +455,9 @@
     };
 
     // buttons evenly spaced
-    btnSell=createButton(120,'SELL',0x006400,()=>handleAction.call(this,'sell'));
-    btnGive=createButton(240,'GIVE FREE',0x008000,()=>handleAction.call(this,'give'));
-    btnRef=createButton(360,'REFUSE',0x800000,()=>handleAction.call(this,'refuse'));
-
-    // emoji icons behind buttons (smaller & less transparent)
-    iconSell=this.add.text(btnSell.x,btnSell.y,'💵',{font:'40px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setAlpha(0.5).setDepth(13).setVisible(false);
-    iconGive=this.add.text(btnGive.x,btnGive.y,'💝',{font:'40px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setAlpha(0.5).setDepth(13).setVisible(false);
-    iconRef=this.add.text(btnRef.x,btnRef.y,'✋',{font:'40px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setAlpha(0.5).setDepth(13).setVisible(false);
+    btnSell=createButton(100,'SELL','💵',32,0x006400,()=>handleAction.call(this,'sell'));
+    btnGive=createButton(240,'GIVE','💝',28,0x008000,()=>handleAction.call(this,'give'));
+    btnRef=createButton(380,'REFUSE','✋',32,0x800000,()=>handleAction.call(this,'refuse'));
 
 
     // sliding report texts
@@ -598,7 +592,6 @@
     if (btnGive.input) btnGive.input.enabled = true;
     btnRef.setVisible(true);
     if (btnRef.input) btnRef.input.enabled = true;
-    iconSell.setVisible(canAfford); iconGive.setVisible(true); iconRef.setVisible(true);
   }
 
   function clearDialog(keepPrice=false){
@@ -621,8 +614,8 @@
     if (btnGive.input) btnGive.input.enabled = false;
     btnRef.setVisible(false);
     if (btnRef.input) btnRef.input.enabled = false;
-    iconSell.setVisible(false); iconGive.setVisible(false); iconRef.setVisible(false);
     tipText.setVisible(false);
+    
   }
 
   function handleAction(type){

--- a/test/test.js
+++ b/test/test.js
@@ -222,7 +222,7 @@ function testStartButtonPlaysIntro() {
 
 function testShowDialogButtons() {
   const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf8');
-  const match = /function showDialog\(\)[\s\S]*?iconRef\.setVisible\(true\);\n\s*\}/.exec(code);
+  const match = /function showDialog\(\)[\s\S]*?btnRef\.setVisible\(true\);[\s\S]*?\}/.exec(code);
   if (!match) throw new Error('showDialog not found');
   const makeObj = () => ({
     visible: false,
@@ -247,9 +247,6 @@ function testShowDialogButtons() {
     btnSell: makeObj(),
     btnGive: makeObj(),
     btnRef: makeObj(),
-    iconSell: makeObj(),
-    iconGive: makeObj(),
-    iconRef: makeObj(),
     tipText: makeObj(),
     activeBubble: null,
     articleFor: () => 'a',


### PR DESCRIPTION
## Summary
- tweak action button layout for better separation
- place button labels and icons inside each button
- update button positions
- remove icon objects and adjust visibility logic
- update tests to match new showDialog implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf7fcbf80832f9dcf41fb938e7e67