### PR TITLE
Hide dialog when Falcon attacks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -890,7 +890,10 @@
   }
 
   function showFalconAttack(cb){
+    if (falconActive) return;
     const scene=this;
+    clearDialog();
+    if(activeBubble){ activeBubble.destroy(); activeBubble=null; }
     falconActive = true;
     gameOver = true;
     if (spawnTimer) { spawnTimer.remove(false); spawnTimer = null; }


### PR DESCRIPTION
## Summary
- hide all dialog UI as soon as a Falcon attack begins
- skip if an attack is already active to avoid duplicate Falcons
- clear leftover speech bubble before attack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d035e4a94832f9c2156fb8622c90f