### PR TITLE
Fix button hit boxes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -454,11 +454,13 @@
         .setSize(width,height)
         .setDepth(12)
         .setVisible(false);
-      c.setInteractive({
-        hitArea:new Phaser.Geom.Rectangle(-width/2,-height/2,width,height),
-        hitAreaCallback:Phaser.Geom.Rectangle.Contains,
-        useHandCursor:true
-      })
+      // Explicitly specify the hit area so the pointer box aligns with the
+      // visible button. Using the direct form avoids Phaser resetting the
+      // rectangle's position when the interactive object is created.
+      c.setInteractive(
+        new Phaser.Geom.Rectangle(-width/2,-height/2,width,height),
+        Phaser.Geom.Rectangle.Contains
+      )
         .on('pointerdown',()=>blinkButton.call(this,c,handler));
       return c;
     };


### PR DESCRIPTION
## Summary
- ensure button hit areas line up with their graphics by specifying a rectangle when setting interactivity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d02ccaae0832f8ee02aa991356857