### PR TITLE
Fix button hit area and spacing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -482,7 +482,7 @@
 
     // helper to create a rounded rectangle button with consistent sizing
     const createButton=(x,label,iconChar,iconSize,color,handler)=>{
-      const width=140, height=50, radius=8;
+      const width=120, height=60, radius=8;
       const g=this.add.graphics();
       // Graphics objects do not support setShadow. Draw a simple shadow
       // manually by rendering a darker rect slightly offset behind the button.


### PR DESCRIPTION
## Summary
- make dialog buttons narrower but taller
- keep the hit boxes centered on the visible buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dbc20895c832f9d757644fcbb27f9