### PR TITLE
Fix button hit area after blinking

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -149,10 +149,11 @@
       repeat: 1,
       onComplete: () => {
         if (btn.setInteractive) {
-          if (btn.width !== undefined && btn.height !== undefined &&
-              Phaser && Phaser.Geom && Phaser.Geom.Rectangle) {
+          const w = btn._hitWidth !== undefined ? btn._hitWidth : btn.width;
+          const h = btn._hitHeight !== undefined ? btn._hitHeight : btn.height;
+          if (w !== undefined && h !== undefined && Phaser && Phaser.Geom && Phaser.Geom.Rectangle) {
             btn.setInteractive(
-              new Phaser.Geom.Rectangle(0, 0, btn.width, btn.height),
+              new Phaser.Geom.Rectangle(0, 0, w, h),
               Phaser.Geom.Rectangle.Contains
             );
           } else {
@@ -505,6 +506,9 @@
         .setSize(width,height)
         .setDepth(12)
         .setVisible(false);
+      // store hit area dimensions for later reactivation
+      c._hitWidth = width;
+      c._hitHeight = height;
       // Explicitly specify the hit area so the pointer box aligns with the
       // visible button. Using the direct form avoids Phaser resetting the
       // rectangle's position when the interactive object is created.


### PR DESCRIPTION
## Summary
- retain button dimensions when created
- use stored dimensions when re-enabling interactivity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc499a28c832f99efb753db948527