### PR TITLE
Fix button hitbox alignment

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -153,7 +153,7 @@
           const h = btn._hitHeight !== undefined ? btn._hitHeight : btn.height;
           if (w !== undefined && h !== undefined && Phaser && Phaser.Geom && Phaser.Geom.Rectangle) {
             btn.setInteractive(
-              new Phaser.Geom.Rectangle(0, 0, w, h),
+              new Phaser.Geom.Rectangle(-w/2, -h/2, w, h),
               Phaser.Geom.Rectangle.Contains
             );
           } else {

--- a/test/test.js
+++ b/test/test.js
@@ -32,8 +32,8 @@ function testBlinkButton() {
   assert(disableCalled, 'disableInteractive not called');
   assert.strictEqual(btn.input.enabled, true, 'button not re-enabled');
   assert.ok(setArgs && setArgs.rect && setArgs.cb, 'setInteractive should be called with shape');
-  assert.strictEqual(setArgs.rect.x, 0, 'hitbox x incorrect');
-  assert.strictEqual(setArgs.rect.y, 0, 'hitbox y incorrect');
+  assert.strictEqual(setArgs.rect.x, -btn.width / 2, 'hitbox x not centered');
+  assert.strictEqual(setArgs.rect.y, -btn.height / 2, 'hitbox y not centered');
   console.log('blinkButton interactivity test passed');
 }
 


### PR DESCRIPTION
## Summary
- ensure dialog buttons use centered hit areas when re-enabled
- update blinkButton test for centered hitbox

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc923f5f0832fa3be7e2dea4f71f0