### PR TITLE
Fix button hitbox centering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -513,7 +513,7 @@
       // visible button. Using the direct form prevents Phaser from shifting the
       // rectangle when enabling input.
       c.setInteractive(
-        new Phaser.Geom.Rectangle(-width/2,-height/2,width,height),
+        new Phaser.Geom.Rectangle(0,0,width,height),
         Phaser.Geom.Rectangle.Contains
       );
       if (c.input) {


### PR DESCRIPTION
## Summary
- restore centered hitbox calculation for dialog buttons
- keep blinkButton re-enabling logic consistent with initial rectangle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc923f5f0832fa3be7e2dea4f71f0