### PR TITLE
Increase customer walking speed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -233,7 +233,7 @@
       const targetY = idx===0 ? ORDER_Y : QUEUE_Y - QUEUE_OFFSET*(idx-1);
       const dist=Phaser.Math.Distance.Between(c.sprite.x,c.sprite.y,targetX,targetY);
       c.sprite.setDepth(5);
-      c.walkTween=scene.tweens.add({targets:c.sprite,x:targetX,y:targetY,scale:scaleForY(targetY),duration:dur(1200+dist*4),ease:'Sine.easeIn',callbackScope:scene,
+      c.walkTween=scene.tweens.add({targets:c.sprite,x:targetX,y:targetY,scale:scaleForY(targetY),duration:dur(800+dist*3),ease:'Sine.easeIn',callbackScope:scene,
         onComplete:()=>{c.walkTween=null; if(idx===0) showDialog.call(scene);} });
     }
   }
@@ -567,7 +567,7 @@
     c.sprite=this.add.sprite(startX,startY,k).setScale(distScale).setDepth(4);
     const amp=Phaser.Math.Between(10,25);
     const freq=Phaser.Math.Between(2,4);
-    c.walkTween=this.tweens.add({targets:c.sprite,x:targetX,duration:dur(12000),onUpdate:(tw,t)=>{
+    c.walkTween=this.tweens.add({targets:c.sprite,x:targetX,duration:dur(8000),onUpdate:(tw,t)=>{
         const p=tw.progress;
         t.y=startY+Math.sin(p*Math.PI*freq)*amp;
       },onComplete:()=>{


### PR DESCRIPTION
## Summary
- make queued customers move to position quicker
- shorten wanderer cross-screen walk time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dce357d34832fb959677f3f5a0242