### PR TITLE
Define button layout constants

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,11 @@
   const START_PHONE_W = 260;
   const START_PHONE_H = 500;
 
+  // dimensions/positioning for the action buttons
+  const BUTTON_WIDTH = 160;
+  const BUTTON_HEIGHT = 60;
+  const BUTTON_Y = 560;
+
 
   let money=10.00, love=10, gameOver=false;
   let queue=[], activeCustomer=null, wanderers=[];
@@ -541,7 +546,7 @@
 
     // helper to create a rounded rectangle button with consistent sizing
     const createButton=(x,label,iconChar,iconSize,color,handler)=>{
-      const width=160, height=60, radius=8;
+      const width=BUTTON_WIDTH, height=BUTTON_HEIGHT, radius=8;
       const g=this.add.graphics();
       // Graphics objects do not support setShadow. Draw a simple shadow
       // manually by rendering a darker rect slightly offset behind the button.
@@ -561,7 +566,7 @@
         children=[g,icon,t];
       }
       // position the button slightly lower so it peeks out of the dialog box
-      const c=this.add.container(x,560,children)
+      const c=this.add.container(x,BUTTON_Y,children)
         .setSize(width,height)
         .setDepth(12)
         .setVisible(false);

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
+const BUTTON_WIDTH = 160;
+const BUTTON_HEIGHT = 60;
+
 function testBlinkButton() {
   const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf8');
   const match = /function blinkButton\(btn, onComplete\)[\s\S]*?\n\s*\}\);\n\s*\}/.exec(code);
@@ -21,8 +24,8 @@ function testBlinkButton() {
   let disableCalled = false;
   let setArgs = null;
   const btn = {
-    width: 160,
-    height: 60,
+    width: BUTTON_WIDTH,
+    height: BUTTON_HEIGHT,
     input: { enabled: true },
     disableInteractive() { disableCalled = true; this.input.enabled = false; },
     setInteractive(rect, cb) { setArgs = { rect, cb }; this.input.enabled = true; }


### PR DESCRIPTION
## Summary
- add BUTTON constants next to layout settings
- use BUTTON constants when creating action buttons
- reference BUTTON constants in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e22d100f0832fbc2e208ab02cc1dd