### PR TITLE
Improve button interactivity

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -154,13 +154,14 @@
         if (btn.setInteractive) {
           if (btn.width !== undefined && btn.height !== undefined &&
               Phaser && Phaser.Geom && Phaser.Geom.Rectangle) {
-            btn.setInteractive(
-              new Phaser.Geom.Rectangle(-btn.width/2, -btn.height/2,
-                                        btn.width, btn.height),
-              Phaser.Geom.Rectangle.Contains
-            );
+            btn.setInteractive({
+              hitArea: new Phaser.Geom.Rectangle(-btn.width/2, -btn.height/2,
+                                               btn.width, btn.height),
+              hitAreaCallback: Phaser.Geom.Rectangle.Contains,
+              useHandCursor: true
+            });
           } else {
-            btn.setInteractive();
+            btn.setInteractive({useHandCursor:true});
           }
         }
         if (onComplete) onComplete();
@@ -568,10 +569,11 @@
       // Explicitly specify the hit area so the pointer box aligns with the
       // visible button. Using the direct form avoids Phaser resetting the
       // rectangle's position when the interactive object is created.
-      c.setInteractive(
-        new Phaser.Geom.Rectangle(-width/2,-height/2,width,height),
-        Phaser.Geom.Rectangle.Contains
-      )
+      c.setInteractive({
+        hitArea: new Phaser.Geom.Rectangle(-width/2,-height/2,width,height),
+        hitAreaCallback: Phaser.Geom.Rectangle.Contains,
+        useHandCursor: true
+      })
         .on('pointerdown',()=>blinkButton.call(this,c,handler));
       return c;
     };


### PR DESCRIPTION
## Summary
- enable hand cursor when blinking buttons re-enable
- use same hand cursor option for buttons created in createButton
- adjust blinkButton test to extract function by parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e22d1e4a4832f812e284d60053dc2