### PR TITLE
Fix hitbox alignment for buttons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -160,7 +160,7 @@
         if (btn.setInteractive) {
           const w = btn.width !== undefined ? btn.width : (btn.displayWidth || 0);
           const h = btn.height !== undefined ? btn.height : (btn.displayHeight || 0);
-          const area = new Phaser.Geom.Rectangle(-w/2, -h/2, w, h);
+          const area = btn.myHitArea || new Phaser.Geom.Rectangle(0, 0, w, h);
           btn.myHitArea = area;
           btn.setInteractive({
             hitArea: area,
@@ -372,18 +372,18 @@
     homeG.fillStyle(0xf0f0f0,1);
     homeG.fillRoundedRect(-phoneW/2+12,phoneH/2-homeH-12,phoneW-24,homeH,20);
 
-    const btnLabel = scene.add.text(0,0,'Clock In',{
-        font:'32px sans-serif',fill:'#fff'})
-      .setOrigin(0.5);
+    const btnLabel = scene.add.text(0,0,'Clock In',{ font:'32px sans-serif',fill:'#fff'})
+      .setOrigin(0.5,0.5);
     const bw = btnLabel.width + 60;
     const bh = btnLabel.height + 20;
     const btnBg = scene.add.graphics();
     btnBg.fillStyle(0x007bff,1);
-    btnBg.fillRoundedRect(-bw/2,-bh/2,bw,bh,15);
+    btnBg.fillRoundedRect(0,0,bw,bh,15);
+    btnLabel.setPosition(bw/2, bh/2);
     const offsetY = phoneH/2 - homeH/2 - 12;
-    startButton = scene.add.container(0,offsetY,[btnBg,btnLabel])
+    startButton = scene.add.container(-bw/2, offsetY - bh/2, [btnBg, btnLabel])
       .setSize(bw,bh);
-    startButton.myHitArea = new Phaser.Geom.Rectangle(-bw/2, -bh/2, bw, bh);
+    startButton.myHitArea = new Phaser.Geom.Rectangle(0, 0, bw, bh);
     startButton.setInteractive({
         hitArea: startButton.myHitArea,
         hitAreaCallback: Phaser.Geom.Rectangle.Contains,
@@ -587,26 +587,26 @@
       // Graphics objects do not support setShadow. Draw a simple shadow
       // manually by rendering a darker rect slightly offset behind the button.
       g.fillStyle(0x000000,0.3);
-      g.fillRoundedRect(-width/2+2,-height/2+2,width,height,radius);
+      g.fillRoundedRect(2,2,width,height,radius);
 
       g.fillStyle(color,1);
-      g.fillRoundedRect(-width/2,-height/2,width,height,radius);
-      let t=this.add.text(-width/2+10,0,label,{font:'20px sans-serif',fill:'#fff'})
+      g.fillRoundedRect(0,0,width,height,radius);
+      let t=this.add.text(10,height/2,label,{font:'20px sans-serif',fill:'#fff'})
         .setOrigin(0,0.5);
-      let icon=this.add.text(width/2-10,0,iconChar,{font:`${iconSize}px sans-serif`,fill:'#fff'})
+      let icon=this.add.text(width-10,height/2,iconChar,{font:`${iconSize}px sans-serif`,fill:'#fff'})
         .setOrigin(1,0.5);
       let children=[g,t,icon];
       if(label==='REFUSE'){
         t.setFontSize(18);
-        icon.setX(width/2-4);
+        icon.setX(width-4);
         children=[g,icon,t];
       }
       // position the button slightly lower so it peeks out of the dialog box
-      const c=this.add.container(x,BUTTON_Y,children)
+      const c=this.add.container(x-width/2,BUTTON_Y-height/2,children)
         .setSize(width,height)
         .setDepth(12)
         .setVisible(false);
-      c.myHitArea = new Phaser.Geom.Rectangle(-width/2,-height/2,width,height);
+      c.myHitArea = new Phaser.Geom.Rectangle(0,0,width,height);
       // Explicitly specify the hit area so the pointer box aligns with the
       // visible button.
       c.setInteractive({

--- a/test/test.js
+++ b/test/test.js
@@ -55,8 +55,8 @@ function testBlinkButton() {
   assert.strictEqual(btn.input.enabled, true, 'button not re-enabled');
   assert.ok(setArgs && setArgs.rect && setArgs.cb, 'setInteractive should be called with shape');
   assert.strictEqual(setArgs.useHand, true, 'useHandCursor should be true');
-  assert.strictEqual(setArgs.rect.x, -btn.width / 2, 'hitbox x not centered');
-  assert.strictEqual(setArgs.rect.y, -btn.height / 2, 'hitbox y not centered');
+  assert.strictEqual(setArgs.rect.x, 0, 'hitbox x not aligned');
+  assert.strictEqual(setArgs.rect.y, 0, 'hitbox y not aligned');
   console.log('blinkButton interactivity test passed');
 }
 
@@ -173,6 +173,7 @@ function testShowStartScreen() {
         const obj = {
           setOrigin() { return obj; },
           setDepth() { return obj; },
+          setPosition() { return obj; },
           width: 100,
           height: 40
         };
@@ -226,7 +227,7 @@ function testStartButtonPlaysIntro() {
   const scene = {
     add: {
       rectangle() { return { setDepth() { return this; }, destroy() { this.destroyed = true; } }; },
-      text() { return { setOrigin() { return this; }, setDepth() { return this; }, width: 100, height: 40 }; },
+      text() { return { setOrigin() { return this; }, setDepth() { return this; }, setPosition() { return this; }, width: 100, height: 40 }; },
       graphics() { return { fillStyle() { return this; }, fillRoundedRect() { return this; } }; },
       container() {
         const obj = {


### PR DESCRIPTION
## Summary
- ensure hit areas use top-left origin and re-enable with saved geometry
- adjust button drawing to account for new origin
- update tests for new hitbox placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e3f8181a8832f89ac9f1f9ee46110