### PR TITLE
Fix button hitbox restoration

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -148,6 +148,10 @@
   }
 
   function blinkButton(btn, onComplete){
+    const w = btn.width !== undefined ? btn.width : (btn.displayWidth || 0);
+    const h = btn.height !== undefined ? btn.height : (btn.displayHeight || 0);
+    const area = btn.myHitArea || new Phaser.Geom.Rectangle(-w/2, -h/2, w, h);
+    btn.myHitArea = area;
     btn.disableInteractive();
     this.tweens.add({
       targets: btn,
@@ -157,18 +161,14 @@
       repeat: 1,
       onComplete: () => {
         if (btn.setInteractive) {
-          const w = btn.width !== undefined ? btn.width : (btn.displayWidth || 0);
-          const h = btn.height !== undefined ? btn.height : (btn.displayHeight || 0);
-          const area = new Phaser.Geom.Rectangle(-w/2, -h/2, w, h);
-          btn.myHitArea = area;
           btn.setInteractive({
-            hitArea: area,
+            hitArea: btn.myHitArea,
             hitAreaCallback: Phaser.Geom.Rectangle.Contains,
             useHandCursor: true
           });
           if (btn.input && btn.input.hitArea) {
-            btn.input.hitArea.x = area.x;
-            btn.input.hitArea.y = area.y;
+            btn.input.hitArea.x = btn.myHitArea.x;
+            btn.input.hitArea.y = btn.myHitArea.y;
           }
         }
         if (onComplete) onComplete();


### PR DESCRIPTION
## Summary
- preserve button hit areas when the blink animation resets interactivity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5707a16c832fb7c6a3228c48e1d0