### PR TITLE
Clean up start screen timer arrays

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -346,8 +346,11 @@
   function showStartScreen(scene){
     scene = scene || this;
     if (typeof debugLog === 'function') debugLog('showStartScreen called');
-    if (typeof startMsgTimers === 'undefined') startMsgTimers = [];
-    if (typeof startMsgBubbles === 'undefined') startMsgBubbles = [];
+    // reset any pending timers or bubbles from a previous session
+    startMsgTimers.forEach(t => t.remove(false));
+    startMsgTimers = [];
+    startMsgBubbles.forEach(b => b.destroy());
+    startMsgBubbles = [];
     startOverlay = scene.add.rectangle(240,320,480,640,0x000000,0.5)
       .setDepth(14);
 
@@ -395,11 +398,7 @@
       .setDepth(15)
       .setInteractive();
 
-    // remove any prior timers or bubbles if restartGame triggered this screen
-    startMsgTimers.forEach(t=>t.remove(false));
-    startMsgTimers=[];
-    startMsgBubbles.forEach(b=>b.destroy());
-    startMsgBubbles=[];
+    // track where to place the first start message
     let startMsgY = -phoneH/2 + 20;
 
     const addStartMessage=(text)=>{

--- a/test/test.js
+++ b/test/test.js
@@ -164,7 +164,7 @@ function testShowStartScreen() {
   const context = { Phaser: { Geom: { Rectangle: RectStub } } };
   vm.createContext(context);
   context.fn = null;
-  vm.runInContext('let startOverlay,startButton;const playIntro=()=>{};\n' + match[0] + '\nfn=showStartScreen;', context);
+  vm.runInContext('let startOverlay,startButton,startMsgTimers=[],startMsgBubbles=[];const playIntro=()=>{};\n' + match[0] + '\nfn=showStartScreen;', context);
   const showStartScreen = context.fn;
   const calls = { rects: 0, text: null, container: null };
   const scene = {
@@ -213,7 +213,7 @@ function testStartButtonPlaysIntro() {
   vm.createContext(context);
   context.fnStart = null;
   context.fnIntro = null;
-  vm.runInContext('var startOverlay,startButton,truck,girl; const dur=v=>v;\n' +
+  vm.runInContext('var startOverlay,startButton,truck,girl,startMsgTimers=[],startMsgBubbles=[]; const dur=v=>v;\n' +
     introMatch[0] + '\n' + startMatch[0] + '\nfnStart=showStartScreen; fnIntro=playIntro;', context);
   const showStartScreen = context.fnStart;
   const realPlayIntro = context.fnIntro;


### PR DESCRIPTION
## Summary
- reset message timer arrays at the start of `showStartScreen`
- drop unused `typeof` checks
- adjust tests for new expectation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e5b47d948832f90c01302251c113a