### PR TITLE
Fix unused vars linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "extends": "eslint:recommended",
     "rules": {
-      "no-unused-vars": "off"
+      "no-unused-vars": "warn"
     }
   },
   "license": "MIT"

--- a/src/main.js
+++ b/src/main.js
@@ -152,9 +152,6 @@
     // Recalculate the hit area afterwards in case the button
     // changed size or scale during the tween.
 
-    const w = btn.width !== undefined ? btn.width : (btn.displayWidth || 0);
-    const h = btn.height !== undefined ? btn.height : (btn.displayHeight || 0);
-
     btn.disableInteractive();
     this.tweens.add({
       targets: btn,
@@ -167,8 +164,6 @@
 
           const w = btn.width !== undefined ? btn.width : (btn.displayWidth || 0);
           const h = btn.height !== undefined ? btn.height : (btn.displayHeight || 0);
-          const area = new Phaser.Geom.Rectangle(-w/2, -h/2, w, h);
-
           const area = new Phaser.Geom.Rectangle(-w/2, -h/2, w, h);
           btn.myHitArea = area;
 
@@ -199,7 +194,6 @@
   let truck, girl;
   let activeBubble=null;
   let sideCText;
-  let spawnCount=0;
   let servedCount=0;
   let sideCAlpha=0;
   let sideCFadeTween=null;
@@ -226,17 +220,6 @@
     return calcLoveLevel(love) + 1;
   }
 
-
-  function wanderOff(c, scene){
-    const dir = Phaser.Math.Between(0,1)?1:-1;
-    const targetX = dir===1?520:-40;
-    const targets=[c.sprite];
-
-    wanderers.splice(wanderers.indexOf(c),1);
-    scene.tweens.add({targets:c.sprite,x:targetX,duration:dur(WALK_OFF_BASE),onComplete:()=>{
-        c.sprite.destroy();
-    }});
-  }
 
   function lureNextWanderer(scene){
     if(wanderers.length && queue.length < queueLimit()){
@@ -701,7 +684,6 @@
     lureNextWanderer(this);
     scheduleNextSpawn(this);
 
-    spawnCount++;
   }
 
   function drawDialogBubble(targetX, targetY){
@@ -1362,7 +1344,6 @@
     queue=[];
     Phaser.Actions.Call(wanderers,c=>{ c.sprite.destroy(); });
     wanderers=[];
-    spawnCount=0;
     servedCount=0;
     sideCAlpha=0;
     sideCFadeTween=null;

--- a/test/test.js
+++ b/test/test.js
@@ -65,10 +65,9 @@ function testSpawnCustomer() {
   const match = /function spawnCustomer\(\)[\s\S]*?\n\s*\}\n(?=\s*function)/.exec(code);
   if (!match) throw new Error('spawnCustomer not found');
   const context = {
-    Phaser: { Math: { Between: (min, max) => min }, Utils: { Array: { GetRandom: a => a[0] } } },
+    Phaser: { Math: { Between: min => min }, Utils: { Array: { GetRandom: a => a[0] } } },
     wanderers: [],
     gameOver: false,
-    spawnCount: 0,
     maxWanderers: () => 5,
     scheduleNextSpawn: () => {},
     lureNextWanderer: () => {},
@@ -170,7 +169,7 @@ function testShowStartScreen() {
   const scene = {
     add: {
       rectangle() { calls.rects++; return { setDepth() { return this; } }; },
-      text(x, y, txt, style) {
+      text(x, y, txt) {
         const obj = {
           setOrigin() { return obj; },
           setDepth() { return obj; },
@@ -181,7 +180,7 @@ function testShowStartScreen() {
         return obj;
       },
       graphics() { return { fillStyle() { return this; }, fillRoundedRect() { return this; } }; },
-      container(x,y,children) {
+      container() {
         const obj = {
           setSize() { return obj; },
           setDepth() { return obj; },


### PR DESCRIPTION
## Summary
- enable `no-unused-vars` lint warnings
- clean up unused variables in game and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e5f8a3f90832f8406ed7347508d5a