### PR TITLE
Add syntax lint step

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Then run the automated check. `npm test` relies on `node_modules/.bin/http-serve
 npm test
 ```
 
+The test runner first verifies `src/main.js` parses without syntax errors by
+executing `npm run lint:syntax` as part of the `pretest` script before running
+ESLint.
+
 ## License
 
 This project is released under the MIT License.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Coffee Clicker game",
   "scripts": {
     "start": "http-server -p 8080 -c-1",
-    "pretest": "npm install && npm run lint",
+    "pretest": "npm install && npm run lint:syntax && npm run lint",
     "test": "node test/test.js",
-    "lint": "eslint src/*.js test/*.js"
+    "lint": "eslint src/*.js test/*.js",
+    "lint:syntax": "node -c src/main.js"
   },
   "devDependencies": {
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Summary
- add `lint:syntax` script using `node -c`
- run `lint:syntax` from `pretest`
- explain syntax check step in README

## Testing
- `npm test` *(fails: Identifier 'area' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_684e5fa33f08832fa70c25e210b5c80f