### PR TITLE
Fix missing price box

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -730,8 +730,8 @@ import { debugLog } from './debug.js';
     dialogPriceContainer
       .setPosition(dialogBg.x + dialogBg.width/2 - 60, dialogBg.y - dialogBg.height)
       .setScale(1)
-
       .setVisible(true);
+    dialogPriceContainer.alpha = 1;
     const itemStr=c.orders.map(o=>{
       return o.qty>1 ? `${o.qty} ${o.req}` : o.req;
     }).join(' and ');


### PR DESCRIPTION
## Summary
- reset dialog price box alpha when showing dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e632df94c832f821587336e8ed605