### PR TITLE
Fix delayedCall stub in tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -434,7 +434,14 @@ function testScheduleNextSpawn() {
   vm.createContext(context);
   vm.runInContext(match + '\nfn=scheduleNextSpawn;', context);
   const scheduleNextSpawn = context.fn;
-  const scene = { time: { delayedCall(delay, cb, args, s) { scene.lastDelay = delay; return { remove() {} }; } } };
+  const scene = {
+    time: {
+      delayedCall(delay) {
+        scene.lastDelay = delay;
+        return { remove() {} };
+      }
+    }
+  };
 
   let oldTimer = { removed: false, remove() { this.removed = true; } };
   context.spawnTimer = oldTimer;


### PR DESCRIPTION
## Summary
- adjust delayedCall stub in tests to remove unused parameters

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e6642cb38832f986b9f243449988c