### PR TITLE
Increase start screen overlay opacity

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -338,7 +338,8 @@ import { debugLog } from './debug.js';
     startMsgTimers = [];
     startMsgBubbles.forEach(b => b.destroy());
     startMsgBubbles = [];
-    startOverlay = scene.add.rectangle(240,320,480,640,0x000000,0.5)
+    // Increase opacity of the start screen overlay for a darker background
+    startOverlay = scene.add.rectangle(240,320,480,640,0x000000,0.75)
       .setDepth(14);
 
     const phoneW = (typeof START_PHONE_W === 'number') ? START_PHONE_W : 260;


### PR DESCRIPTION
## Summary
- darken the start screen overlay for better phone focus

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e69ea443c832fafff8f081e24cfde