### PR TITLE
Animate cost from Coffee Girl

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -683,10 +683,23 @@ export let Assets, Scene, Customers, config;
 
     const priceTargetX = dialogBg.x + dialogBg.width/2 - 60;
     const priceTargetY = dialogBg.y - dialogBg.height;
+    const girlX = (typeof girl !== 'undefined' && girl) ? girl.x : dialogBg.x;
+    const girlY = (typeof girl !== 'undefined' && girl) ? girl.y - 20 : dialogBg.y;
     dialogPriceContainer
-      .setPosition(dialogBg.x, dialogBg.y)
-      .setScale(0)
+      .setPosition(girlX, girlY)
+      .setScale(0.2)
       .setVisible(false);
+    if(dialogPriceBox){
+      if(dialogPriceBox.setFillStyle){
+        dialogPriceBox.setFillStyle(0xdddddd,1);
+      }else if(dialogPriceBox.fillStyle){
+        dialogPriceBox.fillStyle(0xdddddd,1);
+      }
+      if(dialogPriceBox.setStrokeStyle){
+        dialogPriceBox.setStrokeStyle(2,0x000000);
+      }
+      dialogPriceBox.fillAlpha=1;
+    }
     dialogPriceContainer.alpha = 1;
     dialogPriceLabel
       .setStyle({fontSize:'14px'})
@@ -704,15 +717,22 @@ export let Assets, Scene, Customers, config;
       ease:'Back.easeOut',
       duration:dur(300),
       onComplete:()=>{
-        dialogPriceContainer.setVisible(true);
-        this.tweens.add({
-          targets:dialogPriceContainer,
-          x:priceTargetX,
-          y:priceTargetY,
-          scale:1,
-          duration:dur(300),
-          ease:'Sine.easeOut'
-        });
+        const showPrice=()=>{
+          dialogPriceContainer.setVisible(true);
+          this.tweens.add({
+            targets:dialogPriceContainer,
+            x:priceTargetX,
+            y:priceTargetY,
+            scale:1,
+            duration:dur(300),
+            ease:'Sine.easeOut'
+          });
+        };
+        if(this.time && this.time.delayedCall){
+          this.time.delayedCall(dur(500), showPrice, [], this);
+        }else{
+          showPrice();
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- make the price ticket shoot out from Coffee Girl half a second after customer dialog
- ensure the ticket starts tiny and grows while moving
- reset ticket box colors consistently before showing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e72c33e00832fa81bdbc30bbe7270