### PR TITLE
Improve leaving emoji and add lint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,15 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      globals: {
+        Phaser: 'readonly'
+      }
+    },
+    rules: {
+      'no-unused-vars': 'warn'
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- add ESLint flat config for tests
- show dialog buttons with fade animation if available
- move leaving coffee emoji closer to the customer's hands
- match exit emoji to the ordered drink
- guard leaveCustomer and fadeInButtons calls to satisfy tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e852f1368832f9f4a8393a120445e