### PR TITLE
Fix heart break timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -878,6 +878,8 @@ export let Assets, Scene, Customers, config;
         }
       }
     });
+    if(typeof fadeInButtons==='function')
+      fadeInButtons.call(this, canAfford);
 
     tipText.setVisible(false);
     btnSell.setVisible(canAfford);
@@ -1183,8 +1185,6 @@ export let Assets, Scene, Customers, config;
     const count=Math.abs(delta);
     const emoji=delta>0?'❤️':'😠';
 
-    if(delta>0) heartBroken=false; else if(delta<0) heartBroken=true;
-    if(typeof updateLoveDisplay==='function') updateLoveDisplay();
 
     const baseX=customer.x - 20*(count-1)/2;
     const baseY=customer.y + 40;
@@ -1218,6 +1218,9 @@ export let Assets, Scene, Customers, config;
       tl.add({targets:h,x:loveText.x,y:loveText.y,scaleX:0,scaleY:1.2,duration:dur(125)});
       tl.add({targets:h,scaleX:1,alpha:0,duration:dur(125),onComplete:()=>{
             love+=delta>0?1:-1;
+            if(idx===0){
+              if(delta>0) heartBroken=false; else if(delta<0) heartBroken=true;
+            }
             if(typeof updateLoveDisplay==='function') updateLoveDisplay();
             updateLevelDisplay();
             h.destroy();


### PR DESCRIPTION
## Summary
- delay broken-heart update until first emoji hits
- restore fading buttons after price animation

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e83741f88832fbc7be27d86e29fab