### PR TITLE
Improve phone crack visuals

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -427,24 +427,6 @@ export let Assets, Scene, Customers, config;
       cracks.lineTo(-phoneW/4, screenTop+screenH*0.55);
       cracks.lineTo(-phoneW/8, screenTop+screenH*0.65);
       cracks.strokePath();
-    }
-    if(phoneDamage>=2){
-      cracks.lineStyle(3,0x000000,0.9);
-      cracks.beginPath();
-      cracks.moveTo(phoneW/2-20, screenTop+screenH*0.1);
-      cracks.lineTo(phoneW/8, screenTop+screenH*0.25);
-      cracks.lineTo(phoneW/4, screenTop+screenH*0.45);
-      cracks.strokePath();
-      const darkH=screenH*0.18;
-      const dark=scene.add.rectangle(0,screenTop,phoneW-12,darkH,0x000000,0.4).setOrigin(0.5,0);
-      container.add(dark);
-    }
-    if(phoneDamage>=3){
-      cracks.beginPath();
-      cracks.moveTo(-phoneW/2+30, screenBottom-screenH*0.1);
-      cracks.lineTo(0, screenBottom-screenH*0.25);
-      cracks.lineTo(phoneW/3, screenBottom-screenH*0.15);
-      cracks.strokePath();
       const flick=scene.add.rectangle(0,screenTop,phoneW-12,screenH,0x000000,0).setOrigin(0.5,0);
       container.add(flick);
       const blink=()=>{
@@ -454,6 +436,40 @@ export let Assets, Scene, Customers, config;
       };
       if(typeof flickerEvent!=='undefined')
         flickerEvent=scene.time.delayedCall(Phaser.Math.Between(1000,2000),blink,[],scene);
+    }
+    if(phoneDamage>=2){
+      cracks.lineStyle(3,0x000000,0.9);
+      cracks.beginPath();
+      cracks.moveTo(phoneW/2-20, screenTop+screenH*0.1);
+      cracks.lineTo(phoneW/8, screenTop+screenH*0.25);
+      cracks.lineTo(phoneW/4, screenTop+screenH*0.45);
+      cracks.strokePath();
+      const p1={x:-phoneW/2+20,y:screenTop+screenH*0.4};
+      const p2={x:-phoneW/4,y:screenTop+screenH*0.55};
+      const p3={x:phoneW/2-20,y:screenTop+screenH*0.1};
+      const p4={x:phoneW/8,y:screenTop+screenH*0.25};
+      const denom=(p1.x-p2.x)*(p3.y-p4.y)-(p1.y-p2.y)*(p3.x-p4.x);
+      let ix=p4.x, iy=p4.y;
+      if(denom!==0){
+        ix=((p1.x*p2.y-p1.y*p2.x)*(p3.x-p4.x)-(p1.x-p2.x)*(p3.x*p4.y-p3.y*p4.x))/denom;
+        iy=((p1.x*p2.y-p1.y*p2.x)*(p3.y-p4.y)-(p1.y-p2.y)*(p3.x*p4.y-p3.y*p4.x))/denom;
+      }
+      const dark=scene.add.graphics();
+      dark.fillStyle(0x000000,0.4);
+      dark.beginPath();
+      dark.moveTo(p1.x,p1.y);
+      dark.lineTo(ix,iy);
+      dark.lineTo(p3.x,p3.y);
+      dark.closePath();
+      dark.fillPath();
+      container.add(dark);
+    }
+    if(phoneDamage>=3){
+      cracks.beginPath();
+      cracks.moveTo(-phoneW/2+30, screenBottom-screenH*0.1);
+      cracks.lineTo(0, screenBottom-screenH*0.25);
+      cracks.lineTo(phoneW/3, screenBottom-screenH*0.15);
+      cracks.strokePath();
     }
     container.add(cracks);
   }


### PR DESCRIPTION
## Summary
- tweak phone crack drawing logic
- show flicker after first crack appears
- darken phone screen wedge when cracks intersect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e94a5567c832fb99cb228e2045133