### PR TITLE
Update README with test prerequisite note

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,19 @@ Customers can now order any of the following drinks:
 
 ## Running tests
 
-Before running the tests, install all dependencies using `npm ci` or `npm install`:
+Before running the tests, **install all dependencies** using `npm ci` or `npm install`:
 
 ```bash
 npm ci
 ```
 
-Then run the automated check. `npm test` relies on `node_modules/.bin/http-server` to start a local server and verify the page responds without errors:
+This step installs all dev dependencies, including `eslint` and `puppeteer`.
+`eslint` is executed automatically via the `pretest` script and `puppeteer`
+drives a headless browser for the integration tests.
+
+After installing the dependencies, run the automated check. `npm test` relies on
+`node_modules/.bin/http-server` to start a local server and verify the page
+responds without errors:
 
 ```bash
 npm test


### PR DESCRIPTION
## Summary
- clarify that all dependencies must be installed before running the tests
- explain that ESLint and Puppeteer are dev dependencies used by the test suite

## Testing
- `npm ci`
- `npm test` *(fails: `eslint` errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee8c7f4ec832f8f4529a4971a8951