### PR TITLE
Remove duplicate calcLoveLevel

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+/* global phoneDamage */
 import { debugLog } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, START_PHONE_W, START_PHONE_H, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_Y, DIALOG_Y } from "./ui.js";
 import { MENU, SPAWN_DELAY, SPAWN_VARIANCE, QUEUE_SPACING, ORDER_X, ORDER_Y, QUEUE_X, QUEUE_OFFSET, QUEUE_Y, WANDER_TOP, WANDER_BOTTOM, BASE_WAITERS, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, maxWanderers as customersMaxWanderers, queueLimit as customersQueueLimit } from "./customers.js";
@@ -19,6 +20,7 @@ export let Assets, Scene, Customers, config;
   let spawnTimer = null;
   let falconActive = false;
   let loveLevel=1;
+  let flickerEvent;
   const keys=[];
   const requiredAssets=['bg','truck','girl','lady_falcon','falcon_end','revolt_end'];
   const genzSprites=[
@@ -228,14 +230,6 @@ export let Assets, Scene, Customers, config;
   let phoneContainer=null;
   let startMsgTimers=[];
   let startMsgBubbles=[];
-
-
-  function calcLoveLevel(v){
-    if(v>=100) return 4;
-    if(v>=50) return 3;
-    if(v>=20) return 2;
-    return 1;
-  }
 
   function maxWanderers(){
     return customersMaxWanderers(love);


### PR DESCRIPTION
## Summary
- remove redundant `calcLoveLevel` implementation from `main.js`
- use the imported version
- clean up surrounding code and declare globals for ESLint

## Testing
- `npm test` *(fails: ReferenceError: dialogPriceBox is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ee88863f0832fafd7097f5912ceee