### PR TITLE
Add dialogPriceBox stub for handleAction tests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,8 @@ export let Assets, Scene, Customers, config;
   let spawnTimer = null;
   let falconActive = false;
   let loveLevel=1;
+  let phoneDamage = 0;
+  let flickerEvent;
   const keys=[];
   const requiredAssets=['bg','truck','girl','lady_falcon','falcon_end','revolt_end'];
   const genzSprites=[

--- a/test/test.js
+++ b/test/test.js
@@ -116,6 +116,7 @@ function testHandleActionSell() {
     reportLine1: { setStyle() { return this; }, setText() { return this; }, setPosition() { return this; }, setScale() { return this; }, setVisible() { return this; }, setColor() { return this; } },
     reportLine2: { setStyle() { return this; }, setText() { return this; }, setPosition() { return this; }, setScale() { return this; }, setVisible() { return this; }, setColor() { return this; } },
     reportLine3: { setStyle() { return this; }, setText() { return this; }, setPosition() { return this; }, setOrigin() { return this; }, setAlpha() { return this; }, setVisible() { return this; }, setColor() { return this; } },
+    dialogPriceBox: { width: 120, height: 80, setVisible() { return this; }, setDepth() { return this; }, setText() { return this; }, setPosition() { return this; }, setScale() { return this; }, setAlpha() { return this; }, setColor() { return this; }, setStrokeStyle() { return this; }, setFillStyle() { return this; }, x: 0, y: 0, fillAlpha: 1 },
     dialogPriceValue: { setVisible() { return this; }, setDepth() { return this; }, setText() { return this; }, setPosition() { return this; }, setScale() { return this; }, setAlpha() { return this; }, setColor() { return this; }, x:0, y:0 },
     dialogPriceContainer: { x:0, y:0, scaleX:1, scaleY:1, setVisible() { return this; }, setPosition(x,y){ this.x=x; this.y=y; return this; }, setScale(s){ this.scaleX=s; this.scaleY=s; return this; } },
     paidStamp: { setText() { return this; }, setScale() { return this; }, setPosition() { return this; }, setAngle() { return this; }, setVisible() { return this; } },
@@ -273,7 +274,7 @@ function testStartButtonPlaysIntro() {
 
 function testShowDialogButtons() {
   const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf8');
-  const match = /function showDialog\(\)[\s\S]*?btnRef\.setVisible\(true\);[\s\S]*?\}/.exec(code);
+  const match = /function showDialog\(\)[\s\S]*?tipText\.setVisible\(false\);[\s\S]*?\n\s*\}/.exec(code);
   if (!match) throw new Error('showDialog not found');
   const makeObj = () => ({
     visible: false,
@@ -316,6 +317,19 @@ function testShowDialogButtons() {
     queue: [],
     activeCustomer: null,
     drawDialogBubble: () => {},
+    fadeInButtons(canAfford) {
+      if (canAfford) {
+        context.btnSell.setVisible(true);
+        if (context.btnSell.input) context.btnSell.input.enabled = true;
+      } else {
+        context.btnSell.setVisible(false);
+        if (context.btnSell.input) context.btnSell.input.enabled = false;
+      }
+      context.btnGive.setVisible(true);
+      if (context.btnGive.input) context.btnGive.input.enabled = true;
+      context.btnRef.setVisible(true);
+      if (context.btnRef.input) context.btnRef.input.enabled = true;
+    },
   };
   const scene = {
     add: { text() { return makeObj(); }, rectangle() { return makeObj(); }, graphics() { return makeObj(); } },


### PR DESCRIPTION
## Summary
- stub `dialogPriceBox` in `test/test.js` so `handleAction` has expected context
- update `test/test.js` to locate `showDialog` correctly
- stub `fadeInButtons` for button visibility checks
- declare `phoneDamage` and `flickerEvent` in `src/main.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ee8c12030832fb079e68945763d05