### PR TITLE
Remove unused global declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
       "sourceType": "module"
     },
     "globals": {
-      "Phaser": "readonly",
-      "phoneDamage": "writable",
-      "flickerEvent": "writable"
+      "Phaser": "readonly"
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-/* global phoneDamage */
 import { debugLog } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, START_PHONE_W, START_PHONE_H, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_Y, DIALOG_Y } from "./ui.js";
 import { MENU, SPAWN_DELAY, SPAWN_VARIANCE, QUEUE_SPACING, ORDER_X, ORDER_Y, QUEUE_X, QUEUE_OFFSET, QUEUE_Y, WANDER_TOP, WANDER_BOTTOM, BASE_WAITERS, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, maxWanderers as customersMaxWanderers, queueLimit as customersQueueLimit } from "./customers.js";


### PR DESCRIPTION
## Summary
- remove `phoneDamage` global comment from `main.js`
- drop `phoneDamage` and `flickerEvent` from ESLint globals

## Testing
- `npm test` *(fails: debugLog is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684eed0d8b9c832f9cbaa96e6a53298b