### PR TITLE
Update receipt stamps and layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-/* global phoneDamage */
 import { debugLog } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, START_PHONE_W, START_PHONE_H, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_Y, DIALOG_Y } from "./ui.js";
 import { MENU, SPAWN_DELAY, SPAWN_VARIANCE, QUEUE_SPACING, ORDER_X, ORDER_Y, QUEUE_X, QUEUE_OFFSET, QUEUE_Y, WANDER_TOP, WANDER_BOTTOM, BASE_WAITERS, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, maxWanderers as customersMaxWanderers, queueLimit as customersQueueLimit } from "./customers.js";
@@ -618,9 +617,9 @@ export let Assets, Scene, Customers, config;
       .setStrokeStyle(2,0x000)
       .setOrigin(0.5);
 
-    dialogPriceLabel=this.add.text(0,-20,'',{font:'14px sans-serif',fill:'#000',align:'center'})
+    dialogPriceLabel=this.add.text(0,-15,'',{font:'14px sans-serif',fill:'#000',align:'center'})
       .setOrigin(0.5);
-    dialogPriceValue=this.add.text(0,10,'',{font:'32px sans-serif',fill:'#000'})
+    dialogPriceValue=this.add.text(20,15,'',{font:'32px sans-serif',fill:'#000'})
       .setOrigin(0.5);
 
     dialogPriceContainer=this.add.container(0,0,[dialogPriceBox, dialogPriceLabel, dialogPriceValue])
@@ -878,13 +877,13 @@ export let Assets, Scene, Customers, config;
       .setStyle({fontSize:'14px',align:'center'})
       .setText('Total\nCost')
       .setOrigin(0.5)
-      .setPosition(0, -20);
+      .setPosition(0, -15);
     dialogPriceValue
       .setStyle({fontSize:'32px'})
       .setText(`$${totalCost.toFixed(2)}`)
       .setColor('#000')
       .setOrigin(0.5)
-      .setPosition(0, 10)
+      .setPosition(20, 15)
       .setScale(1)
       .setAlpha(1);
 
@@ -1046,7 +1045,7 @@ export let Assets, Scene, Customers, config;
       const stampY=ticket.y + t.y * ticket.scaleY;
       paidStamp
         .setText('PAID')
-        .setScale(2)
+        .setScale(1.5)
         .setPosition(stampX, stampY)
         .setAngle(Phaser.Math.Between(-10,10))
         .setVisible(true);
@@ -1061,12 +1060,14 @@ export let Assets, Scene, Customers, config;
       let delay=dur(300);
       if(tip>0){
         this.time.delayedCall(delay,()=>{
-          const tipX = paidStamp.x - ticketW * 0.4;
-          const tipY = paidStamp.y;
+          const ticketH = dialogPriceBox.height;
+          const tipX = ticket.x - ticketW * 0.3;
+          const tipY = ticket.y - ticketH * 0.25;
           tipText
             .setText('TIP')
             .setScale(1.2)
             .setPosition(tipX, tipY)
+            .setAngle(Phaser.Math.Between(-15,15))
             .setVisible(true);
           t.setText(receipt(totalCost + tip));
           flashPrice();
@@ -1108,7 +1109,7 @@ export let Assets, Scene, Customers, config;
       const stampY=ticket.y + t.y * ticket.scaleY;
       lossStamp
         .setText('LOSS')
-        .setScale(2)
+        .setScale(1.5)
         .setPosition(stampX, stampY)
         .setAngle(Phaser.Math.Between(-10,10))
         .setVisible(true);

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ function testBlinkButton() {
     return { x, y, width: w, height: h };
   }
   RectStub.Contains = () => true;
-  const context = { Phaser: { Geom: { Rectangle: RectStub } } };
+  const context = { Phaser: { Geom: { Rectangle: RectStub } }, debugLog() {} };
   vm.createContext(context);
   context.blinkBtn = null;
   vm.runInContext('const dur=v=>v;\n' + match + '\nblinkBtn=blinkButton;', context);
@@ -120,7 +120,7 @@ function testHandleActionSell() {
     dialogPriceValue: { setVisible() { return this; }, setDepth() { return this; }, setText() { return this; }, setPosition() { return this; }, setScale() { return this; }, setAlpha() { return this; }, setColor() { return this; }, x:0, y:0 },
     dialogPriceContainer: { x:0, y:0, scaleX:1, scaleY:1, setVisible() { return this; }, setPosition(x,y){ this.x=x; this.y=y; return this; }, setScale(s){ this.scaleX=s; this.scaleY=s; return this; } },
     paidStamp: { setText() { return this; }, setScale() { return this; }, setPosition() { return this; }, setAngle() { return this; }, setVisible() { return this; } },
-    tipText: { setText() { return this; }, setScale() { return this; }, setPosition() { return this; }, setVisible() { return this; } },
+    tipText: { setText() { return this; }, setScale() { return this; }, setPosition() { return this; }, setAngle() { return this; }, setVisible() { return this; } },
     dialogBg: { setVisible() { return this; } },
     dialogText: { setVisible() { return this; } },
     supers: {},
@@ -155,7 +155,7 @@ function testShowStartScreen() {
     return { x, y, width: w, height: h };
   }
   RectStub.Contains = () => true;
-  const context = { Phaser: { Geom: { Rectangle: RectStub } } };
+  const context = { Phaser: { Geom: { Rectangle: RectStub } }, debugLog() {} };
   vm.createContext(context);
   context.fn = null;
   vm.runInContext('let startOverlay,startButton,startMsgTimers=[],startMsgBubbles=[];const playIntro=()=>{};\n' + match[0] + '\nfn=showStartScreen;', context);
@@ -205,7 +205,7 @@ function testStartButtonPlaysIntro() {
     return { x, y, width: w, height: h };
   }
   RectStub.Contains = () => true;
-  const context = { Phaser: { Geom: { Rectangle: RectStub } }, spawnCustomer: () => {}, scheduleNextSpawn: () => {} };
+  const context = { Phaser: { Geom: { Rectangle: RectStub } }, spawnCustomer: () => {}, scheduleNextSpawn: () => {}, debugLog() {} };
   vm.createContext(context);
   context.fnStart = null;
   context.fnIntro = null;
@@ -288,6 +288,7 @@ function testShowDialogButtons() {
     setAlpha() { return this; },
     setColor() { return this; },
     setScale() { return this; },
+    setAngle() { return this; },
     clear() { return this; },
     lineStyle() { return this; },
     fillStyle() { return this; },


### PR DESCRIPTION
## Summary
- tweak price label/value positions
- shrink PAID and LOSS stamps and adjust tip stamp placement
- expose tip rotation
- support `setAngle` on test stubs
- stub out `debugLog` in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eec1cabac832f8c1008a43500aa45