### PR TITLE
Refactor dialog price box handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -761,8 +761,21 @@ export let Assets, Scene, Customers, config;
       dialogBg.lineTo(bx1, by+1);
       dialogBg.moveTo(tipX, tipY);
       dialogBg.lineTo(bx2, by+1);
-      dialogBg.strokePath();
+    dialogBg.strokePath();
+  }
+  }
+
+  function resetPriceBox(){
+    if(!dialogPriceBox) return;
+    if(dialogPriceBox.setFillStyle){
+      dialogPriceBox.setFillStyle(0xffeeb5,1);
+    } else if(dialogPriceBox.fillStyle){
+      dialogPriceBox.fillStyle(0xffeeb5,1);
     }
+    if(dialogPriceBox.setStrokeStyle){
+      dialogPriceBox.setStrokeStyle(2,0x000000);
+    }
+    dialogPriceBox.fillAlpha = 1;
   }
 
   function showDialog(){
@@ -862,17 +875,7 @@ export let Assets, Scene, Customers, config;
       .setPosition(girlX, girlY)
       .setScale(0.2)
       .setVisible(false);
-      if(dialogPriceBox){
-        if(dialogPriceBox.setFillStyle){
-          dialogPriceBox.setFillStyle(0xffeeb5,1);
-        }else if(dialogPriceBox.fillStyle){
-          dialogPriceBox.fillStyle(0xffeeb5,1);
-      }
-      if(dialogPriceBox.setStrokeStyle){
-        dialogPriceBox.setStrokeStyle(2,0x000000);
-      }
-      dialogPriceBox.fillAlpha=1;
-    }
+    resetPriceBox();
     dialogPriceContainer.alpha = 1;
     dialogPriceLabel
       .setStyle({fontSize:'14px',align:'center'})
@@ -940,30 +943,13 @@ export let Assets, Scene, Customers, config;
       dialogCoins.setVisible(false);
       dialogPriceContainer.setVisible(false);
       dialogPriceValue.setColor('#000');
-
-        if(dialogPriceBox){
-        if(dialogPriceBox.setFillStyle){
-          dialogPriceBox.setFillStyle(0xffeeb5,1);
-        }else if(dialogPriceBox.fillStyle){
-          dialogPriceBox.fillStyle(0xffeeb5,1);
-          }
-        }
-
     }else{
       dialogBg.setVisible(true);
       dialogText.setVisible(false);
       dialogCoins.setVisible(false);
       dialogPriceContainer.setVisible(true);
     }
-      if(dialogPriceBox){
-        if(dialogPriceBox.setFillStyle){
-          dialogPriceBox.setFillStyle(0xffeeb5,1);
-        }else if(dialogPriceBox.fillStyle){
-          dialogPriceBox.fillStyle(0xffeeb5,1);
-      }
-      dialogPriceBox.setStrokeStyle(2,0x000000);
-      dialogPriceBox.fillAlpha = 1;
-    }
+    resetPriceBox();
     btnSell.setVisible(false);
     if (btnSell.input) btnSell.input.enabled = false;
     btnGive.setVisible(false);


### PR DESCRIPTION
## Summary
- add `resetPriceBox` helper for resetting dialog price ticket
- call `resetPriceBox` from `showDialog` and `clearDialog`
- fix indentation around the new helper

## Testing
- `npm test --silent` *(fails: 'phoneDamage' already defined)*

------
https://chatgpt.com/codex/tasks/task_e_684eed11da30832f9fd4c37fb465c9e7