### PR TITLE
Fix dialog visibility during attacks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1179,6 +1179,8 @@ export let Assets, Scene, Customers, config;
   function showFalconAttack(cb){
     if (falconActive) return;
     const scene=this;
+    scene.tweens.killAll();
+    scene.time.removeAllEvents();
     clearDialog();
     if(activeBubble){ activeBubble.destroy(); activeBubble=null; }
     falconActive = true;
@@ -1275,6 +1277,8 @@ export let Assets, Scene, Customers, config;
 
   function showCustomerRevolt(cb){
     const scene=this;
+    scene.tweens.killAll();
+    scene.time.removeAllEvents();
     clearDialog();
     if(activeBubble){ activeBubble.destroy(); activeBubble=null; }
     if (spawnTimer) { spawnTimer.remove(false); spawnTimer = null; }

--- a/test/test.js
+++ b/test/test.js
@@ -331,7 +331,6 @@ function testShowDialogButtons() {
       context.btnRef.setVisible(true);
       if (context.btnRef.input) context.btnRef.input.enabled = true;
     },
-    resetPriceBox: () => {},
   };
   const scene = {
     add: { text() { return makeObj(); }, rectangle() { return makeObj(); }, graphics() { return makeObj(); } },


### PR DESCRIPTION
## Summary
- cancel any existing tweens and timers when a falcon attack or customer revolt begins
- clean up duplicate test helper property to satisfy ESLint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eff4db1fc832fb5f177e81a0e5003