### PR TITLE
Fix price ticket alignment and simplify animation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -961,7 +961,9 @@ export let Assets, Scene, Customers, config;
       const destY=moneyText.y+10;
       t.setVisible(true);
       t.setDepth(paidStamp.depth+1);
+      const baseLeft = t.x - t.displayWidth/2;
       t.setText(receipt(totalCost));
+      t.setPosition(baseLeft + t.displayWidth/2, t.y);
       const stampX=ticket.x + t.x * ticket.scaleX;
       const stampY=ticket.y + t.y * ticket.scaleY;
       paidStamp
@@ -977,7 +979,6 @@ export let Assets, Scene, Customers, config;
         this.tweens.add({targets:t,y:oy-30,duration:dur(100),yoyo:true});
       };
       flashPrice();
-      flashMoney(t,this);
 
       let delay=dur(300);
       if(tip>0){
@@ -985,13 +986,15 @@ export let Assets, Scene, Customers, config;
           const ticketH = dialogPriceBox.height;
           const tipX = ticket.x - ticketW * 0.3;
           const tipY = ticket.y - ticketH * 0.25;
+          const oldLeft = t.x - t.displayWidth/2;
           tipText
-            .setText('TIP')
-            .setScale(1.2)
+            .setText(`+${receipt(tip)} TIP`)
+            .setScale(1.4)
             .setPosition(tipX, tipY)
             .setAngle(Phaser.Math.Between(-15,15))
             .setVisible(true);
           t.setText(receipt(totalCost + tip));
+          t.setPosition(oldLeft + t.displayWidth/2, t.y);
           flashPrice();
         },[],this);
         delay+=dur(300);
@@ -1053,7 +1056,6 @@ export let Assets, Scene, Customers, config;
             animateStatChange(moneyText, this, mD);
             done();
         }});
-        flashMoney(t,this,'#f00');
         if (typeof dialogPriceBox !== 'undefined' && dialogPriceBox) {
           flashBorder(dialogPriceBox,this,0xff0000);
           flashFill(dialogPriceBox,this,0xff0000);


### PR DESCRIPTION
## Summary
- keep the price text aligned when updating
- remove bold flash on ticket totals
- show tip amount in larger text when it appears

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f043a7a30832f8660bdc938f6203f