### PR TITLE
Limit console output to DEBUG mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by 
 
 1. Run `npm start` and open the game in a browser.
 2. If the truck never moves or "Clock In" does nothing, open the browser's developer console (usually F12).
-3. Look for messages like "Asset failed to load" or "init() did not execute."
+3. With debug logging enabled (see step 5), look for messages like
+   "Asset failed to load" or "init() did not execute."
 4. Verify all files in `assets/` load correctly and reload the page.
 5. To enable verbose logging, add `?debug=1` to the page URL or run
    `localStorage.DEBUG = '1'` in the browser console. For example:

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { debugLog } from './debug.js';
+import { debugLog, DEBUG } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, START_PHONE_W, START_PHONE_H, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_Y, DIALOG_Y } from "./ui.js";
 import { MENU, SPAWN_DELAY, SPAWN_VARIANCE, QUEUE_SPACING, ORDER_X, ORDER_Y, QUEUE_X, QUEUE_OFFSET, QUEUE_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, maxWanderers as customersMaxWanderers, queueLimit as customersQueueLimit } from "./customers.js";
 import { baseConfig } from "./scene.js";
@@ -445,7 +445,7 @@ export let Assets, Scene, Customers, config;
 
   function playIntro(scene){
     if(!truck || !girl) {
-      console.warn('playIntro skipped: missing truck or girl');
+      if (DEBUG) console.warn('playIntro skipped: missing truck or girl');
       return;
     }
     if (typeof debugLog === 'function') debugLog('playIntro starting');
@@ -458,7 +458,6 @@ export let Assets, Scene, Customers, config;
 
         if (typeof debugLog === 'function') {
           debugLog('intro finished');
-          debugLog('playIntro finished');
         }
 
         spawnCustomer.call(scene);
@@ -472,7 +471,7 @@ export let Assets, Scene, Customers, config;
   function preload(){
     const loader=this.load;
     loader.on('loaderror', file=>{
-      console.error('Asset failed to load:', file.key || file.src);
+      if (DEBUG) console.error('Asset failed to load:', file.key || file.src);
     });
     loader.image('bg','assets/bg.png');
     loader.image('truck','assets/truck.png');
@@ -493,7 +492,7 @@ export let Assets, Scene, Customers, config;
     const missing=requiredAssets.filter(key=>!this.textures.exists(key));
     if(missing.length){
       const msg='Missing assets: '+missing.join(', ');
-      console.error(msg);
+      if (DEBUG) console.error(msg);
       this.add.text(240,320,msg,{font:'16px sans-serif',fill:'#f00',align:'center',wordWrap:{width:460}})
         .setOrigin(0.5).setDepth(30);
       const retry=this.add.text(240,360,'Retry Loading',{font:'20px sans-serif',fill:'#00f'})
@@ -1489,7 +1488,7 @@ export let Assets, Scene, Customers, config;
     window.addEventListener('load', init);
     setTimeout(() => {
       if (!initCalled) {
-        console.error('init() did not execute');
+        if (DEBUG) console.error('init() did not execute');
         new Phaser.Game({
           type: Phaser.AUTO,
           parent: 'game-container',

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,8 @@ const assert = require('assert');
 
 const { BUTTON_WIDTH, BUTTON_HEIGHT } = require('../src/ui.js');
 
+const DEBUG = process.env.DEBUG === '1';
+
 function testBlinkButton() {
   const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf8');
   const start = code.indexOf('function blinkButton');
@@ -537,7 +539,7 @@ async function run() {
   });
 
   if (errors.length) {
-    console.error('Failed:', errors);
+    if (DEBUG) console.error('Failed:', errors);
     server.kill();
     process.exit(1);
   } else {
@@ -556,6 +558,6 @@ async function run() {
 }
 
 run().catch(err => {
-  console.error(err);
+  if (DEBUG) console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- hide warn/error messages behind `DEBUG` checks
- drop duplicate `playIntro` log message
- clarify debug docs about viewing error logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f085d8560832fabc6df480b72f349