### PR TITLE
Remove obsolete globals from ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,8 +19,6 @@ module.exports = [
     },
     globals: {
       Phaser: 'readonly',
-      phoneDamage: 'writable',
-      flickerEvent: 'writable',
     },
     rules: {
       'no-unused-vars': 'warn',


### PR DESCRIPTION
## Summary
- clean up ESLint globals list

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f084f2b24832f8018841d4b32097c