### PR TITLE
Fix intro truck animation timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -557,8 +557,8 @@ export function setupGame(){
         spawnCustomer.call(scene);
         scheduleNextSpawn(scene);
       }});
-    intro.add({targets:[truck,girl],x:240,duration:dur(600)});
-    intro.add({targets:truck,scale:0.924,duration:dur(600)},0);
+    intro.add({targets:truck,x:240,scale:0.924,duration:dur(600)});
+    intro.add({targets:girl,x:240,duration:dur(600)},0);
     intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)});
     intro.play();
   }


### PR DESCRIPTION
## Summary
- sync truck movement and scale so the truck moves left while zooming in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f1f9f766c832f98b7c3a48747a038