### PR TITLE
Improve test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Coffee Clicker is a small browser game built with [Phaser](https://phaser.io/). 
 
 ## Getting Started
 
-1. From the repository root, start the local development server:
+1. From the repository root, start the local development server. If you haven't
+   installed the dependencies yet, run `npm install` or `npm ci` (or
+   `scripts/setup.sh`):
 
    ```bash
    npm install
@@ -77,7 +79,8 @@ Customers can now order any of the following drinks:
 
 ## Running tests
 
-Before running the tests, **install all dependencies** using `npm ci` or `npm install`:
+Before running `npm test`, **you must** install all dependencies. Run `npm ci`
+(or `npm install`) first, or execute `scripts/setup.sh` to do it automatically:
 
 ```bash
 npm ci

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# Install project dependencies
+set -e
+if command -v npm >/dev/null 2>&1; then
+  npm ci
+else
+  echo "npm not found. Please install Node.js and npm." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- clarify that `npm ci` or `npm install` must run before running tests
- mention optional `scripts/setup.sh` installer
- add simple setup script

## Testing
- `./scripts/setup.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f28cdf8f4832fa603942902296490