### PR TITLE
Reduce truck speed during intro

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -556,8 +556,8 @@ export function setupGame(){
         spawnCustomer.call(scene);
         scheduleNextSpawn(scene);
       }});
-    intro.add({targets:truck,x:240,scale:0.924,duration:dur(600)});
-    intro.add({targets:girl,x:240,duration:dur(600)},0);
+    intro.add({targets:truck,x:240,scale:0.924,duration:dur(1200)});
+    intro.add({targets:girl,x:240,duration:dur(1200)},0);
     intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)});
     intro.play();
   }


### PR DESCRIPTION
## Summary
- slow down the intro truck and girl animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f290a90d0832f9a50e8aba694c63e