### PR TITLE
Fix timing for truck intro animation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -556,9 +556,9 @@ export function setupGame(){
         }
         scheduleNextSpawn(scene);
       }});
-    intro.add({targets:truck,x:240,scale:0.924,duration:dur(1200)});
+    intro.add({targets:truck,x:240,scale:0.924,duration:dur(1500)});
     intro.add({targets:girl,x:240,duration:dur(1200)},0);
-    intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)});
+    intro.add({targets:girl,y:292,duration:dur(300),onStart:()=>girl.setVisible(true)},1200);
     intro.play();
   }
 


### PR DESCRIPTION
## Summary
- slow down truck entry to sync with engine rumble

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f33f0221c832f8c476463c872ed65