### PR TITLE
Fix start screen and test suite

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -422,17 +422,20 @@ export function setupGame(){
     btnBg.fillStyle(0x007bff,1);
     btnBg.fillRoundedRect(-bw/2,-bh/2,bw,bh,15);
     const offsetY = phoneH/2 - homeH/2 - 12;
+    // position the phone closer to the center of the screen
+    const containerY = 320;
+    phoneContainer = scene.add.container(240,containerY,[caseG,blackG,whiteG,homeG])
+      .setDepth(15);
+
     startButton = scene.add.container(0,offsetY,[btnBg,btnLabel])
-      .setSize(bw,bh);
+      .setSize(bw,bh)
+      .setInteractive({ useHandCursor: true });
 
     const startZone = scene.add.zone(0,0,bw,bh).setOrigin(0.5);
     startZone.setInteractive({ useHandCursor:true });
     startButton.add(startZone);
 
-    // position the phone closer to the center of the screen
-    const containerY = 320;
-    phoneContainer = scene.add.container(240,containerY,[caseG,blackG,whiteG,homeG,startButton])
-      .setDepth(15);
+    phoneContainer.add(startButton);
 
     // track where to place the first start message
     let startMsgY = -phoneH/2 + 20;

--- a/test/test.js
+++ b/test/test.js
@@ -77,7 +77,7 @@ function testBlinkButton() {
 
 function testSpawnCustomer() {
   const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'main.js'), 'utf8');
-  const match = /function spawnCustomer\(\)[\s\S]*?\n\s*\}\n(?=\s*function)/.exec(code);
+  const match = /function spawnCustomer\([^)]*\)[\s\S]*?\n\s*\}\n(?=\s*function)/.exec(code);
   if (!match) throw new Error('spawnCustomer not found');
   const context = {
     Phaser: { Math: { Between: min => min }, Utils: { Array: { GetRandom: a => a[0] } } },


### PR DESCRIPTION
## Summary
- allow optional arguments in spawnCustomer test matcher
- create phone container before start button so startButton is last container created
- expose start button container for interactivity check

## Testing
- `DEBUG=1 npm test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f33cb4c18832fa6637006b036b743