### PR TITLE
Fix spawnCustomer test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -99,9 +99,17 @@ function testSpawnCustomer() {
   const spawnCustomer = context.fn;
   const scene = {
     add: {
-      sprite() { return { setScale() { return this; }, setDepth() { return this; }, destroy() {} }; }
+      sprite() {
+        return {
+          setScale() { return this; },
+          setDepth() { return this; },
+          setAngle() { return this; },
+          destroy() {}
+        };
+      }
     },
-    tweens: { add(cfg) { if (cfg.onComplete) cfg.onComplete(); return { progress: 0 }; } }
+    tweens: { add(cfg) { if (cfg.onComplete) cfg.onComplete(); return { progress: 0 }; } },
+    time: { addEvent() { return { remove() {} }; } }
   };
   spawnCustomer.call(scene);
   assert.strictEqual(context.wanderers.length, 1, 'customer not added to wanderers');


### PR DESCRIPTION
## Summary
- update test stubs in `spawnCustomer` unit test so it handles setAngle and followEvent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f346716f4832f9e2b447ea4c30927