### PR TITLE
Simplify customer spawn flow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -678,14 +678,14 @@ export function setupGame(){
           truck.y = 245;
         }
         // Start the first wanderers once the intro finishes
-        spawnCustomer.call(scene,{wanderOnly:true});
+        spawnCustomer.call(scene);
         if(scene.time && scene.time.delayedCall){
           scene.time.delayedCall(500,()=>{
-            spawnCustomer.call(scene,{wanderOnly:true});
+            spawnCustomer.call(scene);
           },[],scene);
           scene.time.delayedCall(1000,()=>scheduleNextSpawn(scene),[],scene);
         }else{
-          spawnCustomer.call(scene,{wanderOnly:true});
+          spawnCustomer.call(scene);
           scheduleNextSpawn(scene);
         }
       }});
@@ -867,8 +867,7 @@ export function setupGame(){
     this.events.on('update', enforceCustomerScaling);
   }
 
-  function spawnCustomer(opts={}){
-    const wanderOnly = opts.wanderOnly || false;
+  function spawnCustomer(){
     if(gameOver) return;
     const createOrder=()=>{
       const coins=Phaser.Math.Between(0,20);
@@ -933,9 +932,13 @@ export function setupGame(){
         c.sprite.destroy();
       }});
     wanderers.push(c);
-    if(!wanderOnly){
-      lureNextWanderer(this);
-      scheduleNextSpawn(this);
+    scheduleNextSpawn(this);
+    if(this.time && this.time.delayedCall){
+      this.time.delayedCall(1000, ()=>{
+        if(queue.length===0 && wanderers.includes(c)){
+          lureNextWanderer(this);
+        }
+      }, [], this);
     }
 
   }

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,7 @@ function testSpawnCustomer() {
     maxWanderers: () => 5,
     scheduleNextSpawn: () => {},
     lureNextWanderer: () => {},
+    sendDogOffscreen: () => {},
     keys: ['c1'],
     MENU: [{ name: 'Coffee', price: 5 }],
     WANDER_TOP: 0,
@@ -109,7 +110,10 @@ function testSpawnCustomer() {
       }
     },
     tweens: { add(cfg) { if (cfg.onComplete) cfg.onComplete(); return { progress: 0 }; } },
-    time: { addEvent() { return { remove() {} }; } }
+    time: {
+      addEvent() { return { remove() {} }; },
+      delayedCall() { return { remove() {} }; }
+    }
   };
   spawnCustomer.call(scene);
   assert.strictEqual(context.wanderers.length, 1, 'customer not added to wanderers');


### PR DESCRIPTION
## Summary
- remove wanderOnly option so every customer starts as a wanderer
- schedule a lure check one second after spawning when no one is queued
- update intro sequence to spawn wanderers with the new API
- adjust unit tests for the new spawn timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f3e492230832fb0b2f007d0fa79a2