### PR TITLE
Improve debug message in showDialog

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -985,6 +985,19 @@ export function setupGame(){
   function showDialog(){
     if(!dialogBg || !dialogText || !dialogCoins || !dialogPriceLabel ||
        !dialogPriceValue || !btnSell || !btnGive || !btnRef){
+      if (DEBUG) {
+        const missing = [
+          !dialogBg && 'dialogBg',
+          !dialogText && 'dialogText',
+          !dialogCoins && 'dialogCoins',
+          !dialogPriceLabel && 'dialogPriceLabel',
+          !dialogPriceValue && 'dialogPriceValue',
+          !btnSell && 'btnSell',
+          !btnGive && 'btnGive',
+          !btnRef && 'btnRef'
+        ].filter(Boolean).join(', ');
+        console.warn(`showDialog skipped: missing ${missing}`);
+      }
       return;
     }
     if(dialogPriceBox) dialogPriceBox.fillAlpha = 1;


### PR DESCRIPTION
## Summary
- warn when showDialog runs before dialog objects are ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f52ac184c832fba537406dc58d70c