### PR TITLE
Use fixed color for dialog bubble

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1058,7 +1058,8 @@ export function setupGame(){
     dialogBg.setScale(0).setVisible(true);
     dialogText.setScale(0);
     dialogCoins.setScale(0);
-    let bubbleColor=0xffffff;
+    // use a static bubble color to avoid expensive image analysis
+    let bubbleColor = 0xffffff;
     drawDialogBubble(c.sprite.x, c.sprite.y, bubbleColor);
 
     const priceTargetXDefault = dialogBg.x + dialogBg.width/2 - 40;


### PR DESCRIPTION
## Summary
- ensure dialog bubble uses a constant color with no image analysis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f528603b0832fbd2f2bcae61628e8