### PR TITLE
Improve showDialog debug output

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1012,20 +1012,21 @@ export function setupGame(){
 
   function showDialog(){
     if (typeof debugLog === 'function') debugLog('showDialog start');
-    if(!dialogBg || !dialogText || !dialogCoins || !dialogPriceLabel ||
-       !dialogPriceValue || !btnSell || !btnGive || !btnRef){
+    const missingElems = [];
+    if (!dialogBg) missingElems.push('dialogBg');
+    if (!dialogText) missingElems.push('dialogText');
+    if (!dialogCoins) missingElems.push('dialogCoins');
+    if (!dialogPriceLabel) missingElems.push('dialogPriceLabel');
+    if (!dialogPriceValue) missingElems.push('dialogPriceValue');
+    if (!btnSell) missingElems.push('btnSell');
+    if (!btnGive) missingElems.push('btnGive');
+    if (!btnRef) missingElems.push('btnRef');
+    if (missingElems.length){
+      if (typeof debugLog === 'function') {
+        debugLog('showDialog early exit, missing:', missingElems.join(', '));
+      }
       if (DEBUG) {
-        const missing = [
-          !dialogBg && 'dialogBg',
-          !dialogText && 'dialogText',
-          !dialogCoins && 'dialogCoins',
-          !dialogPriceLabel && 'dialogPriceLabel',
-          !dialogPriceValue && 'dialogPriceValue',
-          !btnSell && 'btnSell',
-          !btnGive && 'btnGive',
-          !btnRef && 'btnRef'
-        ].filter(Boolean).join(', ');
-        console.warn(`showDialog skipped: missing ${missing}`);
+        console.warn(`showDialog skipped: missing ${missingElems.join(', ')}`);
       }
       return;
     }


### PR DESCRIPTION
## Summary
- add debug logging when dialog elements are missing
- run the game with `?debug=1` to verify new logs

## Testing
- `npm test`
- `node - <<'NODE'
const { spawn } = require('child_process');
const puppeteer = require('puppeteer');
(async () => { const serverPath = require.resolve('http-server/bin/http-server'); const server = spawn(process.execPath, [serverPath, '-p', '8080', '-c-1']); await new Promise(r => setTimeout(r, 1500)); const browser = await puppeteer.launch({ headless: 'new', args:['--no-sandbox','--disable-setuid-sandbox'] }); const page = await browser.newPage(); page.on('console', msg => console.log('PAGE:', msg.text())); await page.goto('http://localhost:8080/?debug=1'); await new Promise(r => setTimeout(r, 3000)); await browser.close(); server.kill();})();
NODE

------
https://chatgpt.com/codex/tasks/task_e_684f5aeb2534832f921199100e386326