### PR TITLE
Fix server cleanup on run() error

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -675,8 +675,8 @@ async function run() {
   }
 }
 
-run().catch(err => {
+run().catch(async err => {
   if (DEBUG) console.error(err);
   process.exitCode = 1;
-  killServer();
+  await killServer();
 });


### PR DESCRIPTION
## Summary
- await `killServer()` when `run()` fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f6940e528832f821f10db63e6690a