### PR TITLE
Add doc tip on showDialog early exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by 
 2. If the truck never moves or "Clock In" does nothing, open the browser's developer console (usually F12).
 3. With debug logging enabled (see step 5), look for messages like
    "Asset failed to load" or "init() did not execute."
-4. Verify all files in `assets/` load correctly and reload the page.
-5. To enable verbose logging, add `?debug=1` to the page URL or run
+4. If customers reach the counter but never order, check for
+   `showDialog early exit` warnings. This usually means initialization
+   failed and some UI elements were never created.
+5. Verify all files in `assets/` load correctly and reload the page.
+6. To enable verbose logging, add `?debug=1` to the page URL or run
    `localStorage.DEBUG = '1'` in the browser console. For example:
 
    ```


### PR DESCRIPTION
## Summary
- document a debugging tip for missing order dialogs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685042f33eec832faf4190464fbc1258