### PR TITLE
Fix order dialog not showing when repositioning queue

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -308,7 +308,24 @@ export function setupGame(){
           cust.walkTween.remove();
           cust.walkTween=null;
         }
-        scene.tweens.add({targets:cust.sprite,x:tx,y:ty,scale:scaleForY(ty),duration:dur(200)});
+        const tween = scene.tweens.add({
+          targets: cust.sprite,
+          x: tx,
+          y: ty,
+          scale: scaleForY(ty),
+          duration: dur(200),
+          onComplete: () => {
+            if(idx===0){
+              if (typeof debugLog === 'function') {
+                debugLog('checkQueueSpacing complete: calling showDialog');
+              }
+              showDialog.call(scene);
+            }
+          }
+        });
+        if(idx===0){
+          cust.walkTween = tween;
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- trigger `showDialog` when checkQueueSpacing moves the front customer
- keep a reference to the tween for the first customer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504e30c758832fbdefc92c324ac946