### PR TITLE
Fix refusal animation resetting dialog

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1066,6 +1066,9 @@ export function setupGame(){
     if(dialogPriceBox) dialogPriceBox.fillAlpha = 1;
     // reset the dialog position in case previous animations moved it
     dialogBg.y = typeof DIALOG_Y === 'number' ? DIALOG_Y : 430;
+    dialogBg.setAlpha(1);
+    dialogText.setAlpha(1);
+    dialogCoins.setAlpha(1);
     activeCustomer=queue[0]||null;
     if(!activeCustomer) return;
     const c=activeCustomer;
@@ -1246,6 +1249,7 @@ export function setupGame(){
       if(typeof dialogBg!=='undefined') objs.push(dialogBg);
       if(typeof dialogText!=='undefined') objs.push(dialogText);
       if(typeof dialogCoins!=='undefined') objs.push(dialogCoins);
+      if(typeof dialogPriceContainer!=='undefined') objs.push(dialogPriceContainer);
       if(this.tweens && objs.length){
         if(type==='refuse'){
           if(dialogBg.setTint) dialogBg.setTint(0xff0000);


### PR DESCRIPTION
## Summary
- ensure the dialog bubble resets its alpha when showing again
- include the price ticket in the refusal tween so it flies off too

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68505a0a5ff8832facc9e920e72926a4