### PR TITLE
Fix falcon and revolt to clear active customer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1634,6 +1634,9 @@ export function setupGame(){
 
     function panicCustomers(){
       const fleeing=[...queue, ...wanderers];
+      if(activeCustomer && !fleeing.includes(activeCustomer)){
+        fleeing.push(activeCustomer);
+      }
       fleeing.forEach(c=>{
         if(c.walkTween){ c.walkTween.stop(); c.walkTween=null; }
         const dir=c.sprite.x<ORDER_X? -1:1;
@@ -1755,6 +1758,9 @@ export function setupGame(){
     };
     gather(queue);
     gather(wanderers);
+    if(activeCustomer){
+      gather([activeCustomer]);
+    }
 
 
 


### PR DESCRIPTION
## Summary
- ensure the active customer panics during a Lady Falcon attack
- add the active customer to the revolt attackers list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68505e8f5130832fadfadf11a7346bc7