### PR TITLE
Fix ticket animation timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1290,8 +1290,9 @@ export function setupGame(){
             clearDialog.call(this, false);
           }});
         } else {
-          const objs = ticket ? bubbleObjs.concat(ticket) : bubbleObjs;
-          this.tweens.add({targets:objs, y:current.sprite.y, scale:0, duration:dur(200), onComplete:()=>{
+          // Only animate the dialog bubble away. Leave the price ticket
+          // visible so it can fly over to the score area.
+          this.tweens.add({targets:bubbleObjs, y:current.sprite.y, scale:0, duration:dur(200), onComplete:()=>{
             clearDialog.call(this, true);
           }});
         }


### PR DESCRIPTION
## Summary
- keep price ticket visible when dialog bubble fades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685066839148832fa87e9df670409a24