### PR TITLE
Fix extra number on heart counter

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1674,7 +1674,6 @@ export function setupGame(){
           love += delta>0?1:-1;
           loveText.setText('❤️ '+love);
           updateLevelDisplay();
-          h.setText(String(love));
           animateStatChange(loveText, this, delta>0?1:-1, true);
         }
       });


### PR DESCRIPTION
## Summary
- stop replacing heart animation text with the current love total

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850687f95e4832fbfcbf64c971323ce