### PR TITLE
Fix drink emoji disappearing on sale

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1275,7 +1275,12 @@ export function setupGame(){
     if (dialogDrinkEmoji.parentContainer !== dialogPriceContainer) {
       dialogPriceContainer.add(dialogDrinkEmoji);
     }
-    dialogDrinkEmoji.setVisible(false);
+    // Keep the drink emoji visible when the price ticket remains on screen
+    if(!keepPrice){
+      dialogDrinkEmoji.setVisible(false);
+    }else{
+      dialogDrinkEmoji.setVisible(true);
+    }
     resetPriceBox();
     btnSell.setVisible(false);
     if (btnSell.input) btnSell.input.enabled = false;


### PR DESCRIPTION
## Summary
- ensure drink emoji remains visible when the price ticket stays onscreen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685068fad6e4832fb054710bc3289ebe