### PR TITLE
Fix refusal dialog drop animation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1354,7 +1354,9 @@ export function setupGame(){
             this.tweens.add({targets:ticket, x:520, alpha:0,
                             duration:dur(300), ease:'Cubic.easeIn'});
           }
-          this.tweens.add({targets:bubbleObjs, y:current.sprite.y+80, scale:1.5, alpha:0,
+          // Move each dialog element downward together rather than
+          // converging on a single absolute Y position.
+          this.tweens.add({targets:bubbleObjs, y:'+=80', scale:1.5, alpha:0,
                           duration:dur(300), ease:'Cubic.easeIn', onComplete:()=>{
             if(dialogBg.clearTint) dialogBg.clearTint();
             if(dialogText.setColor) dialogText.setColor('#000');


### PR DESCRIPTION
## Summary
- ensure refusal dialog objects fall together

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850699f5d60832fa4e74ed096d75788