### PR TITLE
Fix drink emoji animation on give

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1611,6 +1611,24 @@ export function setupGame(){
             if(this.tweens && typeof dialogPriceBox !== 'undefined' && dialogPriceBox){
               this.tweens.add({targets:dialogPriceBox,fillAlpha:0,duration:dur(400)});
             }
+            if(dialogDrinkEmoji){
+              const gx = ticket.x + dialogDrinkEmoji.x * ticket.scaleX;
+              const gy = ticket.y + dialogDrinkEmoji.y * ticket.scaleY;
+              dialogPriceContainer.remove(dialogDrinkEmoji);
+              dialogDrinkEmoji.setPosition(gx, gy);
+              dialogDrinkEmoji.clearTint();
+              const sp = this.add.text(gx, gy, '✨',{font:'18px sans-serif',fill:'#fff'})
+                .setOrigin(0.5).setDepth(dialogDrinkEmoji.depth+1);
+              this.tweens.add({targets:sp,scale:1.5,alpha:0,duration:dur(300),onComplete:()=>sp.destroy()});
+              this.tweens.add({
+                targets: dialogDrinkEmoji,
+                x: customer.x + DRINK_HOLD_OFFSET.x,
+                y: customer.y + DRINK_HOLD_OFFSET.y,
+                scale: 0.3,
+                duration: dur(400),
+                onComplete: () => { dialogDrinkEmoji.attachedTo = customer; }
+              });
+            }
           }});
         tl.play();
       },[],this);


### PR DESCRIPTION
## Summary
- move drink emoji from price ticket to customer when giving an item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68506bbc7eac832fbe4296dec7fbbda9