### PR TITLE
Fix customer not fleeing during Falcon attack

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1786,8 +1786,11 @@ export function setupGame(){
                 }});
         tl.play();
       });
-      queue.length=0; wanderers.length=0;
+      queue.length=0; wanderers.length=0; activeCustomer=null;
     }
+
+    // send everyone scattering immediately in case a new spawn sneaks in
+    panicCustomers();
 
     const falcon=scene.add.sprite(-40,-40,'lady_falcon',0)
       .setScale(1.4,1.68)


### PR DESCRIPTION
## Summary
- clear `activeCustomer` when panicking customers
- panic immediately when Lady Falcon appears

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68506b973354832fa59f85cd01e0eb8b