### PR TITLE
Fix dialog emoji placement during flings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1364,8 +1364,9 @@ export function setupGame(){
       dialogCoins.setVisible(false);
       dialogPriceContainer.setVisible(true);
     }
-    dialogDrinkEmoji.attachedTo = null;
-    if (dialogDrinkEmoji.parentContainer !== dialogPriceContainer) {
+    const flinging = this.tweens && this.tweens.isTweening && this.tweens.isTweening(dialogDrinkEmoji);
+    if (!flinging && !dialogDrinkEmoji.attachedTo &&
+        dialogDrinkEmoji.parentContainer !== dialogPriceContainer) {
       dialogPriceContainer.add(dialogDrinkEmoji);
     }
     // Keep the drink emoji visible when the price ticket remains on screen


### PR DESCRIPTION
## Summary
- prevent `clearDialog` from resetting the drink emoji while it is flinging to the customer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68507dd8dcfc832f96f6944026f287d1