### PR TITLE
Fix queue filling for higher love levels

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -317,8 +317,10 @@ export function setupGame(){
         showDialog.call(scene);
       }
     }
-    if(queue.length < queueLimit()){
+    while(queue.length < queueLimit()){
+      const beforeLen = queue.length;
       lureNextWanderer(scene);
+      if(queue.length === beforeLen) break;
     }
     if(typeof checkQueueSpacing==='function') checkQueueSpacing(scene);
   }


### PR DESCRIPTION
## Summary
- ensure the queue fills up to the current limit by looping lureNextWanderer
- add unit test that moveQueueForward keeps luring until the queue is full
- update dialog tests with missing stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685081215534832fbf9eb1081aca5f4c