### PR TITLE
Add option to skip puppeteer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ npm test
 The test runner automatically runs `npm run lint` as part of the `pretest`
 script before executing the tests.
 
+If you only want to run the quick unit tests, set `SKIP_PUPPETEER=1` or use the
+`test:unit` script. This skips the browser-based integration tests driven by
+Puppeteer:
+
+```bash
+SKIP_PUPPETEER=1 npm test
+# or
+npm run test:unit
+```
+
+Use this when running offline or on systems without a working browser.
+
 ## GitHub Actions
 
 This project runs a continuous integration workflow defined in

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "http-server -p 8080 -c-1",
     "pretest": "test -d node_modules || npm ci && npm run lint",
     "test": "node test/test.js",
+    "test:unit": "SKIP_PUPPETEER=1 node test/test.js",
     "lint": "eslint -c eslint.config.js src/*.js test/*.js",
     "lint:syntax": "sh -c 'for f in src/*.js; do node -c \"$f\"; done'"
   },


### PR DESCRIPTION
## Summary
- support `SKIP_PUPPETEER` in the test runner to skip browser tests
- add `test:unit` script
- document how to disable puppeteer-based tests

## Testing
- `npm run test:unit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850909bcc28832f8b8b131386d7e7ac