### PR TITLE
Add debug log for luring block

### DIFF
--- a/docs/logging-findings.md
+++ b/docs/logging-findings.md
@@ -1,1 +1,5 @@
 After adding logging around the start screen and intro sequence, running the game shows that the pointerdown event fires when the "Clock In" button is clicked. `playIntro` begins immediately and the timeline completes, triggering the spawn of the first customer. These logs help confirm input registration and intro flow.
+
+When debug mode is enabled, `lureNextWanderer` now prints a message when an
+active `walkTween` blocks another wanderer from moving into the queue. This
+helps explain why the queue might appear stuck.

--- a/src/main.js
+++ b/src/main.js
@@ -232,7 +232,12 @@ export function setupGame(){
       debugLog('lureNextWanderer', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
     }
     if(GameState.wanderers.length && GameState.queue.length < queueLimit()){
-      if(GameState.queue.some(c=>c.walkTween)) return;
+      if(GameState.queue.some(c=>c.walkTween)){
+        if (typeof debugLog === 'function') {
+          debugLog('lureNextWanderer abort: walkTween active');
+        }
+        return;
+      }
       let closestIdx=0;
       let minDist=Number.MAX_VALUE;
       for(let i=0;i<GameState.wanderers.length;i++){


### PR DESCRIPTION
## Summary
- log when a wanderer can't be lured due to an active walkTween
- note the new debug message in the logging findings doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a4eafdd8832f992107f158fd7d5d