### PR TITLE
Improve customer luring logic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -231,8 +231,11 @@ export function setupGame(){
     if (typeof debugLog === 'function') {
       debugLog('lureNextWanderer', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
     }
-    if(GameState.wanderers.length && GameState.queue.length < queueLimit()){
-      if(GameState.queue.some(c=>c.walkTween)) return;
+    while(
+      GameState.wanderers.length > 0 &&
+      GameState.queue.length < queueLimit() &&
+      !GameState.queue.some(c => c.walkTween)
+    ){
       let closestIdx=0;
       let minDist=Number.MAX_VALUE;
       for(let i=0;i<GameState.wanderers.length;i++){


### PR DESCRIPTION
## Summary
- lure customers repeatedly while slots are free and no one is moving
- add a unit test covering queue filling at high love levels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850a4d37aa8832fa0d50a9bdd756863