### PR TITLE
Remove unused syntax lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "pretest": "test -d node_modules || npm ci && npm run lint",
     "test": "node test/test.js",
     "test:unit": "SKIP_PUPPETEER=1 node test/test.js",
-    "lint": "eslint -c eslint.config.js src/*.js test/*.js",
-    "lint:syntax": "sh -c 'for f in src/*.js; do node -c \"$f\"; done'"
+    "lint": "eslint -c eslint.config.js src/*.js test/*.js"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
## Summary
- drop redundant `lint:syntax` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c9277d74832fb9ef3d332424a7a1