### PR TITLE
Fix spawnCustomer queue limit check

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1103,7 +1103,7 @@ export function setupGame(){
       }});
 
     GameState.wanderers.push(c);
-    if(GameState.queue.length===0){
+    if(GameState.queue.length < queueLimit()){
 
       lureNextWanderer(this);
     }
@@ -1111,7 +1111,7 @@ export function setupGame(){
     if(this.time && this.time.delayedCall){
       this.time.delayedCall(1000, ()=>{
 
-        if(GameState.queue.length===0 && GameState.wanderers.includes(c)){
+        if(GameState.queue.length < queueLimit() && GameState.wanderers.includes(c)){
 
           lureNextWanderer(this);
         }


### PR DESCRIPTION
## Summary
- adjust spawnCustomer logic to lure wanderers when the queue is below the limit

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6850cf528b98832f9837a2ae1cee847d