### PR TITLE
Add floating emoji helpers

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -12,3 +12,12 @@ export const GameState = {
 };
 
 export const floatingEmojis = [];
+
+export function addFloatingEmoji(emoji) {
+  if (emoji) floatingEmojis.push(emoji);
+}
+
+export function removeFloatingEmoji(emoji) {
+  const idx = floatingEmojis.indexOf(emoji);
+  if (idx !== -1) floatingEmojis.splice(idx, 1);
+}


### PR DESCRIPTION
## Summary
- manage floating emojis through new `addFloatingEmoji` and `removeFloatingEmoji` helpers
- use helpers for emoji animation and cleanup
- keep game logic resilient when helpers aren't defined

## Testing
- `SKIP_PUPPETEER=1 node test/test.js`

------
https://chatgpt.com/codex/tasks/task_e_6850cf1ef3a0832f9fa2df3318166259