### PR TITLE
Remove unused startDialogue hook

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1106,7 +1106,7 @@ export function setupGame(){
           c.dog=null;
         }
         c.sprite.destroy();
-        this.startDialogue && this.startDialogue(c);
+//         this.startDialogue && this.startDialogue(c);
       }});
 
     GameState.wanderers.push(c);


### PR DESCRIPTION
## Summary
- comment out unused startDialogue hook in wanderer cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850d674ec8c832f97e3b34f702639d2