### PR TITLE
Add persistent customer emotions

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -8,10 +8,14 @@ export const GameState = {
   falconActive: false,
   gameOver: false,
   loveLevel: 1,
-  servedCount: 0
+  servedCount: 0,
+  heartWin: null
 };
 
 export const floatingEmojis = [];
+
+export const customerMemory = {};
+GameState.customerMemory = customerMemory;
 
 export function addFloatingEmoji(emoji) {
   if (emoji) floatingEmojis.push(emoji);


### PR DESCRIPTION
## Summary
- track per-customer heart state in `GameState.customerMemory`
- draw heart emoji under each customer
- modify love rewards/penalties based on heart state
- new win condition when giving a drink to an "arrow" heart customer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e16df85c832fa58959742e86d771