### PR TITLE
Fix stamp layering so total appears after stamping

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1600,7 +1600,8 @@ export function setupGame(){
       const destX=moneyText.x+moneyText.width-15;
       const destY=moneyText.y+10;
       t.setVisible(true);
-      t.setDepth(paidStamp.depth+1);
+      // start below the stamp so the stamp appears on top first
+      t.setDepth(paidStamp.depth-1);
       const baseLeft = t.x - t.displayWidth/2;
       t.setText(receipt(totalCost));
       t.setPosition(baseLeft + t.displayWidth/2, t.y);
@@ -1617,6 +1618,10 @@ export function setupGame(){
         .setAngle(Phaser.Math.Between(-10,10))
         .setVisible(true);
       applyRandomSkew(paidStamp);
+      // raise the price above the stamp after the stamp lands
+      this.time.delayedCall(dur(300), () => {
+        t.setDepth(paidStamp.depth + 1);
+      }, [], this);
       t.setPosition(t.x, 15);
 
       const flashPrice=()=>{
@@ -1682,7 +1687,8 @@ export function setupGame(){
       const destX=moneyText.x+moneyText.width-15;
       const destY=moneyText.y+10;
       t.setVisible(true)
-        .setDepth(lossStamp.depth+1);
+        // start below the stamp so the stamp animation appears on top
+        .setDepth(lossStamp.depth-1);
       const stampX=ticket.x + Phaser.Math.Between(-5,5);
       const stampY=ticket.y + Phaser.Math.Between(-5,5);
       lossStamp
@@ -1692,6 +1698,10 @@ export function setupGame(){
         .setAngle(Phaser.Math.Between(-10,10))
         .setVisible(true);
       applyRandomSkew(lossStamp);
+      // raise the price above the stamp after the stamp lands
+      this.time.delayedCall(dur(300), () => {
+        t.setDepth(lossStamp.depth + 1);
+      }, [], this);
       t.setPosition(t.x, 15);
       this.time.delayedCall(dur(1000),()=>{
         lossStamp.setVisible(false);


### PR DESCRIPTION
## Summary
- adjust SALE and GIVE stamp behavior so the price appears above the stamp when the stamping finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850ec61b420832fa12b6b62da480682