### PR TITLE
Fix simultaneous spawn at start

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -840,15 +840,6 @@ export function setupGame(){
         }
         // Start the first wanderers once the intro finishes
         spawnCustomer.call(scene);
-        if(scene.time && scene.time.delayedCall){
-          scene.time.delayedCall(500,()=>{
-            spawnCustomer.call(scene);
-          },[],scene);
-          scene.time.delayedCall(1000,()=>scheduleNextSpawn(scene),[],scene);
-        }else{
-          spawnCustomer.call(scene);
-          scheduleNextSpawn(scene);
-        }
       }});
     intro.add({targets:truck,x:240,scale:0.924,duration:dur(1500),ease:'Sine.easeOut'});
     intro.add({targets:girl,x:240,duration:dur(1200)},0);


### PR DESCRIPTION
## Summary
- remove extra spawn calls in intro so customers spawn sequentially

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850ec957448832fa12671aaed80f3c0