### PR TITLE
Add node version preflight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Coffee Clicker is a small browser game built with [Phaser](https://phaser.io/). 
 ## Getting Started
 
 This project requires **Node.js 20**. Newer versions (21+) are not yet supported.
+Running `npm install` (or `npm ci`) triggers a preinstall check that verifies
+`node --version` falls within `>=20 <21`. If it doesn't, the install exits with
+an error.
 
 1. From the repository root, start the local development server. If you haven't
    installed the dependencies yet, run `npm install` or `npm ci` (or

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Coffee Clicker game",
   "type": "commonjs",
   "scripts": {
+    "preinstall": "scripts/check-node-version.sh",
     "start": "http-server -p 8080 -c-1",
     "pretest": "test -d node_modules || npm ci && npm run lint",
     "test": "node test/test.js",

--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Verify Node.js version >=20 <21
+set -e
+REQUIRED=">=20 <21"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js not found. Please install a version $REQUIRED." >&2
+  exit 1
+fi
+
+raw="$(node --version)"
+version=${raw#v}
+major=${version%%.*}
+
+# exit if major not 20
+if [ "$major" -lt 20 ] || [ "$major" -ge 21 ]; then
+  echo "Unsupported Node.js version $raw. Required $REQUIRED." >&2
+  exit 1
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 # Install project dependencies
 set -e
+
+# Ensure supported Node.js version
+DIR="$(cd "$(dirname "$0")" && pwd)"
+"$DIR/check-node-version.sh"
+
 if command -v npm >/dev/null 2>&1; then
   npm ci
 else


### PR DESCRIPTION
## Summary
- add `check-node-version.sh` preflight script
- run preflight check from `setup.sh`
- run preflight automatically via `npm preinstall`
- document node version check in README

## Testing
- `scripts/check-node-version.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850fb90b290832f98084c326e41ed16