### PR TITLE
Fix Lady Falcon panic freeze

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1817,7 +1817,7 @@ export function setupGame(){
         current.sprite.destroy();
         if(GameState.money<=0){
           showFalconAttack.call(this,()=>{
-            showEnd.call(this,'Game Over\nYou lost all the money.\nLady Falcon reclaims the coffee truck.');
+            showEnd.call(this,'Game Over\nYou lost all the money.\nLady Falcon reclaims the coffee truck.', null, {keepTweens:true});
           });
           return;
         }
@@ -2459,10 +2459,13 @@ export function setupGame(){
     });
   }
 
-  function showEnd(msg, bigEmoji){
+  function showEnd(msg, bigEmoji, opts){
     const scene=this;
-    scene.tweens.killAll();
-    scene.time.removeAllEvents();
+    const keepTweens = opts && opts.keepTweens;
+    if(!keepTweens){
+      scene.tweens.killAll();
+      scene.time.removeAllEvents();
+    }
     cleanupFloatingEmojis();
     cleanupHeartEmojis();
     hideOverlayTexts();


### PR DESCRIPTION
## Summary
- allow `showEnd` to skip killing tweens
- keep customer escape tweens running during Lady Falcon attack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851bce3cbec832f918ff8b4e676519f