### PR TITLE
Fix lingering Game Over zone

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2508,6 +2508,7 @@ export function setupGame(){
         bg.destroy(); txt.destroy(); btn.destroy(); if(titleText) titleText.destroy(); if(img) img.destroy();
         if(endOverlay){ endOverlay.destroy(); endOverlay=null; }
         restartGame.call(this);
+        againZone.destroy();
       });
     GameState.gameOver=true;
   }


### PR DESCRIPTION
## Summary
- destroy `againZone` after clicking `Try Again` to prevent stray input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851c1d4b16c832fa525ca088ea33148