### PR TITLE
Fix canvas creation

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -1,6 +1,11 @@
+const canvas = document.createElement('canvas');
+const context = canvas.getContext('2d', { willReadFrequently: true });
+
 export const baseConfig = {
   type: Phaser.AUTO,
   parent: 'game-container',
+  canvas,
+  context,
   backgroundColor: '#f2e5d7',
   scale: {
     mode: Phaser.Scale.FIT,
@@ -8,8 +13,5 @@ export const baseConfig = {
     width: 480,
     height: 640
   },
-  pixelArt: true,
-  contextCreation: {
-    willReadFrequently: true
-  }
+  pixelArt: true
 };


### PR DESCRIPTION
## Summary
- create a canvas with a 2D context
- expose the canvas and context in Phaser config
- drop the obsolete `contextCreation` property

## Testing
- `npm test` *(fails: Unsupported Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_6852257b80a4832fb9965e4db238cd52