### PR TITLE
Expose startWander and use in customer spawns

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -17,7 +17,7 @@ import {
 } from '../customers.js';
 import { GameState } from '../state.js';
 import { CustomerState } from '../constants.js';
-import { showDialog, Assets } from '../main.js';
+import { showDialog, Assets, startWander } from '../main.js';
 
 const CUSTOMER_SPEED = 560 / 6;
 const LURE_SPEED = CUSTOMER_SPEED * 0.6;
@@ -269,7 +269,7 @@ export function spawnCustomer() {
       default: return 0;
     }
   });
-  const startW = (typeof startWander === 'function') ? startWander : function (scene, cust, targetX, exitAfter) {
+  const startW = typeof startWander === 'function' ? startWander : function(scene, cust, targetX, exitAfter) {
     const duration = (typeof dur === 'function') ? dur(1000) : 1000;
     cust.walkData = { startX: cust.sprite.x, startY: cust.sprite.y, targetX, amp: 0, freq: 0, duration, exitAfter };
     if (scene && scene.tweens && scene.tweens.add) {

--- a/src/main.js
+++ b/src/main.js
@@ -2160,4 +2160,4 @@ if (typeof window !== 'undefined') {
   setupGame();
 }
 
-export { showStartScreenFn as showStartScreen, handleActionFn as handleAction, spawnCustomerFn as spawnCustomer, scheduleNextSpawnFn as scheduleNextSpawn, showDialogFn as showDialog, animateLoveChangeFn as animateLoveChange, blinkButtonFn as blinkButton };
+export { showStartScreenFn as showStartScreen, handleActionFn as handleAction, spawnCustomerFn as spawnCustomer, scheduleNextSpawnFn as scheduleNextSpawn, showDialogFn as showDialog, animateLoveChangeFn as animateLoveChange, blinkButtonFn as blinkButton, startWander };


### PR DESCRIPTION
## Summary
- export `startWander` from `src/main.js`
- import `startWander` in customer queue and use if present

## Testing
- `DEBUG=1 SKIP_PUPPETEER=1 node test/test.js` *(fails: Error: spawnCustomer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852278f5e6c832f8568027f863c2995