### PR TITLE
Refactor helpers and customer logic

### DIFF
--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -1,0 +1,77 @@
+import { GameState } from '../state.js';
+import { dur, scaleForY } from '../ui.js';
+import { sendDogOffscreen } from './dog.js';
+
+const EDGE_TURN_BUFFER = 40;
+
+export function loopsForState(state){
+  switch(state){
+    case 'growing': return 1;
+    case 'sparkling':
+    case 'arrow':
+      return 2;
+    default: return 0;
+  }
+}
+
+export function removeWanderer(scene, c){
+  const idx = GameState.wanderers.indexOf(c);
+  if(idx >= 0) GameState.wanderers.splice(idx,1);
+  const ex = c.sprite.x, ey = c.sprite.y;
+  if(c.dog){
+    sendDogOffscreen.call(scene,c.dog,ex,ey);
+    c.dog = null;
+  }
+  if(c.heartEmoji){ c.heartEmoji.destroy(); c.heartEmoji = null; }
+  c.sprite.destroy();
+}
+
+export function handleWanderComplete(scene, c){
+  if(c.loopsRemaining > 0){
+    c.loopsRemaining--;
+    c.dir *= -1;
+    const inside = c.dir === 1 ? 480-EDGE_TURN_BUFFER : EDGE_TURN_BUFFER;
+    const exitX = c.dir === 1 ? 520 : -40;
+    const target = c.loopsRemaining > 0 ? inside : exitX;
+    startWander(scene,c,target,c.loopsRemaining===0);
+  }else{
+    removeWanderer(scene,c);
+  }
+}
+
+export function startWander(scene, c, targetX, exitAfter){
+  if(c.walkTween){ c.walkTween.stop(); c.walkTween.remove(); c.walkTween=null; }
+  const startX=c.sprite.x;
+  const startY=c.sprite.y;
+  const amp = Phaser.Math.Between(15,30);
+  const freq = Phaser.Math.FloatBetween ? Phaser.Math.FloatBetween(1.5,4.5) : Phaser.Math.Between(15,45)/10;
+  const walkDuration = Phaser.Math.Between(5000,7000);
+  c.walkData={startX,startY,targetX,amp,freq,duration:walkDuration,exitAfter};
+  c.walkTween = scene.tweens.add({targets:c.sprite,x:targetX,duration:dur(walkDuration),
+    onUpdate:(tw,t)=>{
+      const p=tw.progress;
+      t.y=startY+Math.sin(p*Math.PI*freq)*amp;
+      t.setScale(scaleForY(t.y));
+    },
+    onComplete:()=>{ exitAfter ? removeWanderer(scene,c) : handleWanderComplete(scene,c); }
+  });
+}
+
+export function resumeWanderer(scene, c){
+  if(!c || !c.sprite || !c.walkData) return;
+  const {targetX,startX,startY,amp,freq,duration,exitAfter} = c.walkData;
+  const totalDist = Math.abs(targetX - startX);
+  const remaining = Math.abs(targetX - c.sprite.x);
+  const walkDuration = totalDist>0 ? duration * (remaining/totalDist) : duration;
+  c.walkTween = scene.tweens.add({
+    targets:c.sprite,
+    x:targetX,
+    duration:dur(walkDuration),
+    onUpdate:(tw,t)=>{
+      const p=tw.progress;
+      t.y=startY+Math.sin(p*Math.PI*freq)*amp;
+      t.setScale(scaleForY(t.y));
+    },
+    onComplete:()=>{ exitAfter ? removeWanderer(scene,c) : handleWanderComplete(scene,c); }
+  });
+}

--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -1,0 +1,69 @@
+export function flashBorder(rect, scene, color=0x00ff00){
+  if(!rect || !rect.setStrokeStyle) return;
+  const original=rect.strokeColor||0x000000;
+  let on=false;
+  const flashes=4;
+  scene.time.addEvent({
+    repeat:flashes,
+    delay:scene.dur ? scene.dur(60) : 60,
+    callback:()=>{
+      rect.setStrokeStyle(2, on?color:original);
+      on=!on;
+    }
+  });
+  scene.time.delayedCall((scene.dur ? scene.dur(60) : 60)*(flashes+1)+(scene.dur?scene.dur(10):10),()=>{
+    rect.setStrokeStyle(2, original);
+  },[],scene);
+}
+
+export function flashFill(rect, scene, color=0x00ff00){
+  if(!rect || !rect.setFillStyle) return;
+  const original=rect.fillColor||0xffffff;
+  let on=false;
+  const flashes=4;
+  scene.time.addEvent({
+    repeat:flashes,
+    delay:scene.dur ? scene.dur(60) : 60,
+    callback:()=>{
+      rect.setFillStyle(on?color:original,1);
+      on=!on;
+    }
+  });
+  scene.time.delayedCall((scene.dur?scene.dur(60):60)*(flashes+1)+(scene.dur?scene.dur(10):10),()=>{
+    rect.setFillStyle(original,1);
+  },[],scene);
+}
+
+export function blinkButton(btn, onComplete, inputObj){
+  const target = inputObj || btn;
+  if (target.input) {
+    target.input.enabled = false;
+  }
+  this.tweens.add({
+    targets: btn,
+    alpha: 0,
+    yoyo: true,
+    duration: this.dur ? this.dur(80) : 80,
+    repeat: 1,
+    onComplete: () => {
+      if (target.input) {
+        target.input.enabled = true;
+      }
+      if (onComplete) onComplete();
+    }
+  });
+}
+
+export function applyRandomSkew(obj){
+  if(!obj) return;
+  const randFloat = Phaser.Math.FloatBetween || ((a,b)=>Phaser.Math.Between(a*1000,b*1000)/1000);
+  obj.skewX = randFloat(-0.03, 0.03);
+  obj.skewY = randFloat(-0.03, 0.03);
+}
+
+export function emphasizePrice(text){
+  if(!text || !text.setStyle) return;
+  text.setStyle({fontStyle:'bold', stroke:'#fff', strokeThickness:2});
+}
+
+export { blinkButton as default };


### PR DESCRIPTION
## Summary
- move customer wandering helpers to entities module
- add ui helper module with small effects
- use new helpers in `main.js` and remove old code

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685227607894832f87396bd877cf2f3c