### PR TITLE
Fix start screen button click area

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -80,9 +80,12 @@ function showStartScreen(scene){
   bigBird5.anims.play('sparrow3_ground');
   phoneContainer.add([bigBird4,bigBird1,bigBird2,bigBird3,bigBird5]);
 
+  // The button container itself doesn't need its own hit area. Setting
+  // it interactive caused the clickable region to be offset from the
+  // visible graphics on some devices. Rely solely on the centered zone
+  // for input handling instead.
   startButton = scene.add.container(0,offsetY,[btnBg,btnLabel])
-    .setSize(bw,bh)
-    .setInteractive({ useHandCursor: true });
+    .setSize(bw,bh);
 
   const startZone = scene.add.zone(0,0,bw,bh).setOrigin(0.5);
   startZone.setInteractive({ useHandCursor:true });


### PR DESCRIPTION
## Summary
- fix hit area for the start button so users can tap "Clock In" on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852457f9a4c832fbcc4c79bdaa55eb6