### PR TITLE
Fix duplicate game setup causing start screen issues

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1673,7 +1673,7 @@ export function setupGame(){
 }
 
 if (typeof window !== 'undefined') {
-  setupGame();
+  // game.js calls setupGame() when loaded. Avoid running twice.
 }
 
 export { showStartScreenFn as showStartScreen, handleActionFn as handleAction, spawnCustomerFn as spawnCustomer, scheduleNextSpawnFn as scheduleNextSpawn, showDialogFn as showDialog, animateLoveChangeFn as animateLoveChange, blinkButtonFn as blinkButton, startWander };


### PR DESCRIPTION
## Summary
- avoid calling `setupGame` twice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531d668794832f91fa72488017f456