### PR TITLE
Ensure dogs exit screen during falcon attack

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -1,4 +1,4 @@
-import { ORDER_Y } from '../customers.js';
+import { ORDER_X, ORDER_Y } from '../customers.js';
 import { GameState } from '../state.js';
 import { dur, scaleForY } from '../ui.js';
 
@@ -155,16 +155,22 @@ export function sendDogOffscreen(dog, x, y) {
 export function cleanupDogs(scene){
   const gs = scene.gameState || GameState;
   if(gs.activeCustomer && gs.activeCustomer.dog){
-    if(gs.activeCustomer.dog.followEvent) gs.activeCustomer.dog.followEvent.remove(false);
-    gs.activeCustomer.dog.destroy();
+    const dog = gs.activeCustomer.dog;
+    if(dog.followEvent) dog.followEvent.remove(false);
+    const dir = dog.x < ORDER_X ? -1 : 1;
+    const targetX = dir===1 ? 520 : -40;
+    sendDogOffscreen.call(scene, dog, targetX, dog.y);
     gs.activeCustomer.dog = null;
   }
   [gs.queue, gs.wanderers].forEach(arr => {
     if(Array.isArray(arr)){
       arr.forEach(c => {
         if(c.dog){
-          if(c.dog.followEvent) c.dog.followEvent.remove(false);
-          c.dog.destroy();
+          const dog = c.dog;
+          if(dog.followEvent) dog.followEvent.remove(false);
+          const dir = dog.x < ORDER_X ? -1 : 1;
+          const targetX = dir===1 ? 520 : -40;
+          sendDogOffscreen.call(scene, dog, targetX, dog.y);
           c.dog = null;
         }
       });

--- a/src/main.js
+++ b/src/main.js
@@ -1287,12 +1287,14 @@ export function setupGame(){
           known.add(child);
         }
       });
-      // remove any loose dogs not associated with a customer
+      // send any loose dogs scurrying off screen instead of deleting them
       scene.children.list.forEach(child=>{
         if(child instanceof Phaser.GameObjects.Text &&
            DOG_TYPES.some(d=>d.emoji===child.text) &&
            !fleeing.some(c=>c.dog===child)){
-          child.destroy();
+          const dir=child.x<ORDER_X? -1:1;
+          const targetX=dir===1?520:-40;
+          sendDogOffscreen.call(scene, child, targetX, child.y);
         }
       });
 


### PR DESCRIPTION
## Summary
- make loose dogs run off screen during a falcon attack
- let `cleanupDogs` send dogs offscreen instead of instantly destroying them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685350e7f144832f9108f0bb22dd4915