### PR TITLE
Fix stuck queue when tweens killed

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -48,6 +48,13 @@ export function lureNextWanderer(scene, specific) {
     debugLog('lureNextWanderer', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
   }
 
+  // clear stale tween references that were stopped externally
+  GameState.queue.forEach(c => {
+    if (c.walkTween && !c.walkTween.isPlaying) {
+      c.walkTween = null;
+    }
+  });
+
   if (GameState.wanderers.length && GameState.queue.length < queueLimit()) {
     if (GameState.queue.some(c => c.walkTween)) {
       if (typeof debugLog === 'function') {


### PR DESCRIPTION
## Summary
- clear stale walkTween references before luring next wanderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685350489588832f99f02308d6996b79