### PR TITLE
Fix falcon end timing and dog panic exit

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1317,12 +1317,14 @@ export function setupGame(){
         tl.add({targets:c.sprite,
                 x:targetX,
                 duration:dur(WALK_OFF_BASE/1.5),
-                onComplete:()=>{
-                  const ex=c.sprite.x, ey=c.sprite.y;
+                onStart:()=>{
                   if(c.dog){
-                    sendDogOffscreen.call(scene,c.dog,ex,ey);
+                    scene.tweens.killTweensOf(c.dog);
+                    sendDogOffscreen.call(scene,c.dog,targetX,c.sprite.y);
                     c.dog=null;
                   }
+                },
+                onComplete:()=>{
                   c.sprite.destroy();
                   remaining--;
                   if(remaining===0 && done) done();
@@ -1343,7 +1345,6 @@ export function setupGame(){
             const dy=girl.y+Math.sin(ang)*r;
             dTl.add({targets:dog,x:dx,y:dy,duration:dur(Phaser.Math.Between(200,350)),ease:'Sine.easeInOut'});
           }
-          dTl.add({targets:dog,x:targetX,y:dog.y,duration:dur(WALK_OFF_BASE/1.5),onComplete:()=>dog.destroy()});
           dTl.setCallback('onUpdate',()=>{
             if(dog.prevX===undefined) dog.prevX=dog.x;
             const dx=dog.x-dog.prevX;
@@ -1353,7 +1354,6 @@ export function setupGame(){
             dog.setScale(s*(dog.dir||1), s);
           });
           dTl.play();
-          c.dog=null;
         }
       });
       // keep references so restartGame can properly clean up any remaining
@@ -1370,6 +1370,8 @@ export function setupGame(){
       if(falcon) falcon.destroy();
       if(cb) cb();
     };
+    let piecesDone=0;
+    const tryEnd=()=>{ if(++piecesDone>=2) endAttack(); };
     panicCustomers();
 
     falcon=scene.add.sprite(-40,-40,'lady_falcon',0)
@@ -1385,9 +1387,9 @@ export function setupGame(){
       duration:dur(900),
       ease:'Cubic.easeIn',
       onComplete:()=>{
-        panicCustomers(endAttack);
+        panicCustomers(tryEnd);
         blinkAngry(scene);
-        const tl=scene.tweens.createTimeline({callbackScope:scene,onComplete:endAttack});
+        const tl=scene.tweens.createTimeline({callbackScope:scene,onComplete:tryEnd});
         for(let i=0;i<4;i++){
           tl.add({targets:falcon,y:targetY+10,duration:dur(80),yoyo:true});
           tl.add({targets:girl,y:girl.y+5,duration:dur(80),yoyo:true,


### PR DESCRIPTION
## Summary
- adjust dog panic behavior so dogs follow owners offscreen
- wait for all panic and falcon animations before showing end screen

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68536050e144832f9cb55b3b4481fbe8