### PR TITLE
Allow queueing while front customer moves

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -56,7 +56,7 @@ export function lureNextWanderer(scene, specific) {
   });
 
   if (GameState.wanderers.length && GameState.queue.length < queueLimit()) {
-    if (GameState.queue.some(c => c.walkTween)) {
+    if (GameState.queue.some((c, i) => i > 0 && c.walkTween)) {
       if (typeof debugLog === 'function') {
         debugLog('lureNextWanderer abort: walkTween active');
       }


### PR DESCRIPTION
## Summary
- allow `lureNextWanderer` to run even if the first queued customer is still moving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685360f18024832fbd90ef5fd79b8533