### PR TITLE
Smooth wanderer edge turns

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -85,6 +85,7 @@ export function lureNextWanderer(scene, specific) {
       c.walkTween.remove();
       c.walkTween = null;
     }
+    if (c.pauseEvent) { c.pauseEvent.remove(); c.pauseEvent = null; }
     const idx = GameState.queue.length;
     c.atOrder = false;
     GameState.queue.push(c);
@@ -239,7 +240,7 @@ export function spawnCustomer() {
     return { coins, req: item.name, price: item.price, qty };
   };
 
-  const c = { orders: [] };
+  const c = { orders: [], pauseEvent: null };
   const used = new Set();
   if (GameState.activeCustomer && GameState.activeCustomer.spriteKey) {
     used.add(GameState.activeCustomer.spriteKey);

--- a/src/intro.js
+++ b/src/intro.js
@@ -158,6 +158,7 @@ function pauseWanderersForTruck(scene){
         c.walkTween.remove();
         c.walkTween=null;
       }
+      if(c.pauseEvent){ c.pauseEvent.remove(); c.pauseEvent=null; }
       scene.tweens.add({targets:c.sprite,y:'-=20',duration:dur(150),yoyo:true});
       scene.time.delayedCall(dur(1000),()=>{
         if(GameState.girlReady && GameState.queue.length < queueLimit() && GameState.wanderers.includes(c)){


### PR DESCRIPTION
## Summary
- pause briefly when wanderers reach the edge so the turn isn't abrupt
- stop pause timers when wanderers get lured, paused, or removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685373ef6dc4832f9885ea50c3e18639