### PR TITLE
Slow down wanderers and queue movement

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -23,7 +23,8 @@ import { startWander, loopsForState } from './wanderers.js';
 import { DOG_TYPES, updateDog } from './dog.js';
 
 
-const CUSTOMER_SPEED = 560 / 6;
+// Slow down queue movement to match wander speed change
+const CUSTOMER_SPEED = 560 / 12;
 const LURE_SPEED = CUSTOMER_SPEED * 0.6;
 const EDGE_TURN_BUFFER = 40;
 const HEART_EMOJIS = {

--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -45,7 +45,8 @@ export function startWander(scene, c, targetX, exitAfter){
   const startY=c.sprite.y;
   const amp = Phaser.Math.Between(15,30);
   const freq = Phaser.Math.FloatBetween ? Phaser.Math.FloatBetween(1.5,4.5) : Phaser.Math.Between(15,45)/10;
-  const walkDuration = Phaser.Math.Between(5000,7000);
+  // Slower wander speed now that the line is working
+  const walkDuration = Phaser.Math.Between(10000,14000);
   c.walkData={startX,startY,targetX,amp,freq,duration:walkDuration,exitAfter};
   c.walkTween = scene.tweens.add({targets:c.sprite,x:targetX,duration:dur(walkDuration),
     onUpdate:(tw,t)=>{

--- a/src/main.js
+++ b/src/main.js
@@ -15,11 +15,12 @@ import { showStartScreen, playIntro } from './intro.js';
 
 export let Assets, Scene, Customers, config;
 export let showStartScreenFn, handleActionFn, spawnCustomerFn, scheduleNextSpawnFn, showDialogFn, animateLoveChangeFn, blinkButtonFn;
-const CUSTOMER_SPEED = 560 / 6; // pixels per second for wanderers
+// Customers move slower now that the line works better
+const CUSTOMER_SPEED = 560 / 12; // pixels per second for wanderers and queue
 // Minimum duration when a customer dashes to the table
 const DART_MIN_DURATION = 300;
 // Maximum speed (pixels per second) when dashing to the table
-const DART_MAX_SPEED = CUSTOMER_SPEED * 3;
+const DART_MAX_SPEED = (560 / 6) * 3;
 // Offset for the drink emoji when the customer holds it
 // Raise it slightly so it appears near their hands instead of their feet
 const DRINK_HOLD_OFFSET = { x: 0, y: -20 };


### PR DESCRIPTION
## Summary
- slow wanderer walk duration
- reduce customer base speed and queue speed
- keep dash speed the same

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685373b98e84832fb4383f6b5b4d06fd