### PR TITLE
Switch dogs to sprite-based graphics

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -43,6 +43,7 @@ export function preload(){
   loader.spritesheet('sparrow','assets/sparrow.png',{frameWidth:16,frameHeight:16});
   loader.spritesheet('sparrow2','assets/sparrow2.png',{frameWidth:20,frameHeight:20});
   loader.spritesheet('sparrow3','assets/sparrow3.png',{frameWidth:20,frameHeight:20});
+  loader.spritesheet('dog1','assets/dog1.png',{frameWidth:100,frameHeight:100});
   for(const k of genzSprites){
     keys.push(k);
     requiredAssets.push(k);

--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -303,10 +303,11 @@ export function spawnCustomer() {
     const offsetX = side * Phaser.Math.Between(20, 30);
     const offsetY = Phaser.Math.Between(10, 20);
     const dogType = Phaser.Utils.Array.GetRandom(DOG_TYPES);
-    const dog = this.add.text(startX + offsetX, startY + offsetY, dogType.emoji, { font: '32px sans-serif' })
+    const dog = this.add.sprite(startX + offsetX, startY + offsetY, 'dog1', 1)
       .setOrigin(0.5)
       .setScale(distScale * 0.5)
-      .setDepth(3);
+      .setDepth(3)
+      .setTint(dogType.tint || 0xffffff);
     dog.dir = 1;
     dog.prevX = dog.x;
     dog.dogType = dogType.type;

--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -7,10 +7,10 @@ export const DOG_MIN_Y = ORDER_Y + 20;
 export const DOG_SPEED = 120; // base movement speed for the dog
 export const DOG_FAST_DISTANCE = 160; // accelerate when farther than this from owner
 export const DOG_TYPES = [
-  { type: 'standard', emoji: '🐶' },
-  { type: 'poodle', emoji: '🐩' },
-  { type: 'guide', emoji: '🦮' },
-  { type: 'service', emoji: '🐕‍🦺' }
+  { type: 'standard', emoji: '🐶', tint: 0xffffff },
+  { type: 'poodle', emoji: '🐩', tint: 0xffc0cb },
+  { type: 'guide', emoji: '🦮', tint: 0xffff66 },
+  { type: 'service', emoji: '🐕‍🦺', tint: 0xffaa00 }
 ];
 
 export function scaleDog(d) {
@@ -67,8 +67,9 @@ export function updateDog(owner) {
         const s = scaleForY(dog.y) * 0.5;
         dog.setScale(s * (dog.dir || 1), s);
       });
-      tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; });
+      tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); });
       dog.currentTween = tl;
+      dog.play && dog.play('dog_walk');
       tl.play();
       return;
     }
@@ -100,9 +101,10 @@ export function updateDog(owner) {
      Phaser.Math.Distance.Between(dog.x, dog.y, ORDER_X, ORDER_Y) < 60 &&
      !dog.hasBarked){
     dog.hasBarked = true;
-    const bark = this.add.text(dog.x, dog.y - 20, 'BARK!', {
-      font: '16px sans-serif', fill: '#000'
-    }).setOrigin(0.5).setDepth(dog.depth + 1);
+    const bark = this.add.sprite(dog.x, dog.y - 20, 'dog1', 3)
+      .setOrigin(0.5)
+      .setDepth(dog.depth + 1)
+      .setScale(dog.scaleX, dog.scaleY);
     this.tweens.add({
       targets: bark,
       y: '-=20',
@@ -120,6 +122,7 @@ export function updateDog(owner) {
   if (Math.abs(targetX - dog.x) > 3) {
     dog.dir = targetX > dog.x ? 1 : -1;
   }
+  dog.play && dog.play('dog_walk');
   dog.currentTween = this.tweens.add({
     targets: dog,
     x: targetX,
@@ -139,6 +142,7 @@ export function updateDog(owner) {
     },
     onComplete: () => {
       dog.currentTween = null;
+      dog.setFrame(1);
     }
   });
 }
@@ -150,6 +154,7 @@ export function sendDogOffscreen(dog, x, y) {
   if (Math.abs(x - dog.x) > 3) {
     dog.dir = x > dog.x ? 1 : -1;
   }
+  dog.play && dog.play('dog_walk');
   this.tweens.add({
     targets: dog,
     x,

--- a/src/main.js
+++ b/src/main.js
@@ -364,6 +364,15 @@ export function setupGame(){
       repeat:-1
     });
 
+    // dog animations
+    this.anims.create({
+      key:'dog_walk',
+      frames:this.anims.generateFrameNumbers('dog1',{start:0,end:1}),
+      frameRate:4,
+      repeat:-1
+    });
+    this.anims.create({ key:'dog_bark', frames:[{key:'dog1',frame:2}], frameRate:1 });
+
     // dialog
     dialogBg=this.add.graphics()
       .setVisible(false)
@@ -1351,8 +1360,9 @@ export function setupGame(){
         if(c.dog){
           const dog=c.dog;
           if(dog.followEvent) dog.followEvent.remove(false);
-          const bark=scene.add.text(dog.x,dog.y-20,'BARK!',{font:'16px sans-serif',fill:'#000'})
-            .setOrigin(0.5).setDepth(dog.depth+1);
+          const bark=scene.add.sprite(dog.x,dog.y-20,'dog1',3)
+            .setOrigin(0.5).setDepth(dog.depth+1)
+            .setScale(dog.scaleX,dog.scaleY);
           scene.tweens.add({targets:bark,y:'-=20',alpha:0,duration:dur(600),onComplete:()=>bark.destroy()});
           const dTl=scene.tweens.createTimeline();
           for(let j=0;j<4;j++){
@@ -1370,6 +1380,8 @@ export function setupGame(){
             const s=scaleForY(dog.y)*0.5;
             dog.setScale(s*(dog.dir||1), s);
           });
+          dTl.setCallback('onComplete',()=>{dog.setFrame(1);});
+          dog.play && dog.play('dog_walk');
           dTl.play();
         }
       });


### PR DESCRIPTION
## Summary
- add dog1 sprite sheet to assets and load it
- tint dog sprites for different dog types
- spawn dogs using sprite graphics instead of emoji text
- show bark effect using sprite frame
- play dog walking animation during movement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685377dd5a64832faa734d14c542d0ef