### PR TITLE
Fix tip text position

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1011,8 +1011,10 @@ export function setupGame(){
       // raise the price above the stamp after the stamp lands
       this.time.delayedCall(dur(300), () => {
         if (dialogPriceValue.parentContainer) {
+          const m = dialogPriceValue.getWorldTransformMatrix();
           dialogPriceContainer.remove(dialogPriceValue);
           this.add.existing(dialogPriceValue);
+          dialogPriceValue.setPosition(m.tx, m.ty);
         }
         t.setDepth(paidStamp.depth + 1);
         blinkPriceBorder(t, this);


### PR DESCRIPTION
## Summary
- correct dialog price label world position when removing from container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685378df8e8c832fb50d16510d986bc4