### PR TITLE
Make Pup Cup free for dogs only

### DIFF
--- a/src/customers.js
+++ b/src/customers.js
@@ -21,8 +21,7 @@ export const MENU = [
   {name:"Pink Crush", price:5.70},
   {name:"Iced Under the Pink", price:6.10},
   {name:"Iced Rose Tea", price:5.70},
-  {name:"Iced Starry Night Tea", price:5.70},
-  {name:"Pup Cup", price:1.00}
+  {name:"Iced Starry Night Tea", price:5.70}
 ];
 
 export const SPAWN_DELAY = 2000;

--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -347,7 +347,7 @@ export function spawnCustomer() {
     const dogCust = {
       sprite: dog,
       spriteKey: 'dog1',
-      orders: [{ coins: 1, req: 'Pup Cup', price: 1.00, qty: 1 }],
+      orders: [{ coins: 0, req: 'PUP CUP', price: 0.00, qty: 1 }],
       dir: c.dir,
       memory: { state: CustomerState.NORMAL },
       atOrder: false,

--- a/src/main.js
+++ b/src/main.js
@@ -574,6 +574,10 @@ export function setupGame(){
     GameState.activeCustomer=GameState.queue[0]||null;
     if(!GameState.activeCustomer) return;
     const c=GameState.activeCustomer;
+    if(!c.isDog && c.dog && c.dog.followEvent){
+      c.dog.followEvent.remove(false);
+      c.dog.followEvent=null;
+    }
     if(!c.atOrder && (c.sprite.y!==ORDER_Y || c.sprite.x!==ORDER_X)){
       c.atOrder=true;
       const dist = Phaser.Math.Distance.Between(c.sprite.x, c.sprite.y, ORDER_X, ORDER_Y);
@@ -678,8 +682,8 @@ export function setupGame(){
       .setOrigin(1,0)
       .setPosition(dialogPriceBox.width/2-5, -dialogPriceBox.height/2+5);
     dialogPriceValue
-      .setStyle({fontSize:'40px'})
-      .setText(c.isDog?'pup cup':receipt(totalCost))
+      .setStyle({fontSize:'32px'})
+      .setText(c.isDog?'PUP CUP':receipt(totalCost))
       .setColor('#000')
       .setOrigin(0.5)
       .setPosition(0, 15)


### PR DESCRIPTION
## Summary
- stop dogs from wandering when their owner is ordering
- remove the Pup Cup from the human menu
- make the dog order free and show `PUP CUP` in a smaller font

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68538f96099c832f9bbaad36c6a08dca