### PR TITLE
Fix lureNextWanderer retry condition

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -60,7 +60,7 @@ export function lureNextWanderer(scene, specific) {
   });
 
   if (GameState.wanderers.length && GameState.queue.length < queueLimit()) {
-    if (GameState.queue.some((c, i) => i > 0 && c.walkTween)) {
+    if (GameState.queue.some((c, i) => i > 0 && c.walkTween && c.walkTween.isPlaying)) {
       if (typeof debugLog === 'function') {
         debugLog('lureNextWanderer abort: walkTween active');
       }


### PR DESCRIPTION
## Summary
- only abort luring when an actual tween is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68538eb17670832f95a78be69a8af801