### PR TITLE
Prevent stuck queue when tween active

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -64,6 +64,9 @@ export function lureNextWanderer(scene, specific) {
       if (typeof debugLog === 'function') {
         debugLog('lureNextWanderer abort: walkTween active');
       }
+      if (scene && scene.time && scene.time.delayedCall) {
+        scene.time.delayedCall(250, () => lureNextWanderer(scene, specific), [], scene);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- retry lureNextWanderer after detecting an active walkTween

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685394f78d78832fb6d78f4b1475cc16