### PR TITLE
Fix wanderer lure freeze

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -64,6 +64,12 @@ export function lureNextWanderer(scene, specific) {
       if (typeof debugLog === 'function') {
         debugLog('lureNextWanderer abort: walkTween active');
       }
+      if (!GameState.lureRetry && scene.time && scene.time.delayedCall) {
+        GameState.lureRetry = scene.time.delayedCall(500, () => {
+          GameState.lureRetry = null;
+          lureNextWanderer(scene, specific);
+        }, [], scene);
+      }
       return;
     }
 

--- a/src/state.js
+++ b/src/state.js
@@ -6,6 +6,7 @@ export const GameState = {
   wanderers: [],
   sparrows: [],
   spawnTimer: null,
+  lureRetry: null,
   sparrowSpawnEvent: null,
   falconActive: false,
   gameOver: false,


### PR DESCRIPTION
## Summary
- retry `lureNextWanderer` when movement tween blocks new customers
- track pending retry timer in `GameState`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685394f78d78832fb6d78f4b1475cc16