### PR TITLE
Fix sparrow cleanup

### DIFF
--- a/src/sparrow.js
+++ b/src/sparrow.js
@@ -289,8 +289,23 @@ export function updateSparrows(scene, delta){
   const dt = delta/1000;
   const birds = scene.gameState.sparrows;
   if(!Array.isArray(birds)) return;
-  for(const bird of birds){
+  for(const bird of birds.slice()){
     bird.update(dt);
+    if(!bird.sprite) continue;
+    const y = bird.sprite.y;
+    if(y < -50 || y > scene.scale.height + 50){
+      if(bird.threatCheck && bird.threatCheck.remove){
+        bird.threatCheck.remove(false);
+      }
+      if(bird.timerEvent && bird.timerEvent.remove){
+        bird.timerEvent.remove(false);
+      }
+      if(bird.destroy){
+        bird.destroy();
+      }
+      const idx = birds.indexOf(bird);
+      if(idx !== -1) birds.splice(idx,1);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- remove sparrows when they exit the scene
- include bird timer cleanup
- expose BirdState constant in unit tests
- test that off-screen sparrows are removed

## Testing
- `npm run test:unit` *(fails: playIntro not called)*

------
https://chatgpt.com/codex/tasks/task_e_6853a23a2644832fa74881e67dcd4447