### PR TITLE
Fix layering using sprite bottom

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -21,6 +21,7 @@ import { CustomerState } from '../constants.js';
 import { showDialog, Assets } from '../main.js';
 import { startWander, loopsForState } from './wanderers.js';
 import { DOG_TYPES, updateDog, scaleDog } from './dog.js';
+import { setDepthFromBottom } from '../ui/helpers.js';
 
 
 // Slow down queue movement to match wander speed change
@@ -108,8 +109,7 @@ export function lureNextWanderer(scene, specific) {
     GameState.activeCustomer = GameState.queue[0];
     const targetX = ORDER_X;
     const targetY = ORDER_Y;
-    const bottomY = c.sprite.y + c.sprite.displayHeight * (1 - c.sprite.originY);
-    c.sprite.setDepth(5 + bottomY * 0.006);
+    setDepthFromBottom(c.sprite, 5);
     const dir = c.dir || (c.sprite.x < targetX ? 1 : -1);
     c.walkTween = curvedApproach(scene, c.sprite, dir, targetX, targetY, () => {
       c.walkTween = null;
@@ -319,8 +319,7 @@ export function spawnCustomer() {
   c.orders.push(order);
   c.atOrder = false;
   c.sprite = this.add.sprite(startX, startY, k).setScale(distScale);
-  const bottomYStart = startY + c.sprite.displayHeight * (1 - c.sprite.originY);
-  c.sprite.setDepth(5 + bottomYStart * 0.006);
+  setDepthFromBottom(c.sprite, 5);
   if (c.memory.state !== CustomerState.NORMAL) {
     c.heartEmoji = this.add.text(0, 0, HEART_EMOJIS[c.memory.state] || '', { font: '28px sans-serif' })
       .setOrigin(0.5)

--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -1,6 +1,7 @@
 import { ORDER_X, ORDER_Y } from '../customers.js';
 import { GameState } from '../state.js';
 import { dur, scaleForY } from '../ui.js';
+import { setDepthFromBottom } from '../ui/helpers.js';
 import { scatterSparrows } from '../sparrow.js';
 
 export const DOG_MIN_Y = ORDER_Y + 20;
@@ -21,8 +22,7 @@ export function scaleDog(d) {
   const s = scaleForY(d.y) * factor;
   const dir = d.dir || 1;
   d.setScale(s * dir, s);
-  const bottomY = d.y + d.displayHeight * (1 - d.originY);
-  d.setDepth(3 + bottomY * 0.006);
+  setDepthFromBottom(d, 3);
 }
 
 // Keep the dog positioned near its owner and react to other customers.
@@ -160,8 +160,7 @@ export function updateDog(owner) {
       t.prevX = t.x;
       const s = scaleForY(t.y) * (t.scaleFactor || 0.6);
       t.setScale(s * (t.dir || 1), s);
-      const bottomY = t.y + t.displayHeight * (1 - t.originY);
-      t.setDepth(3 + bottomY * 0.006);
+      setDepthFromBottom(t, 3);
     },
     onComplete: () => {
       dog.currentTween = null;
@@ -194,8 +193,7 @@ export function sendDogOffscreen(dog, x, y) {
       t.prevX = t.x;
       const s = scaleForY(t.y) * (t.scaleFactor || 0.6);
       t.setScale(s * (t.dir || 1), s);
-      const bottomY = t.y + t.displayHeight * (1 - t.originY);
-      t.setDepth(3 + bottomY * 0.006);
+      setDepthFromBottom(t, 3);
     },
     onComplete: () => dog.destroy()
   });

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { CustomerState } from './constants.js';
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows } from './sparrow.js';
 import { DOG_TYPES, sendDogOffscreen, scaleDog, cleanupDogs } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
-import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, blinkPriceBorder } from './ui/helpers.js';
+import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, blinkPriceBorder, setDepthFromBottom } from './ui/helpers.js';
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { showStartScreen, playIntro } from './intro.js';
 
@@ -166,11 +166,6 @@ export function setupGame(){
 
 
   function enforceCustomerScaling(){
-    const setDepth = (sprite, base=5)=>{
-      if(!sprite) return;
-      const bottomY = sprite.y + sprite.displayHeight * (1 - sprite.originY);
-      sprite.setDepth(base + bottomY*0.006);
-    };
       const updateHeart = c => {
         if(!c.sprite || !c.sprite.scene) return;
       const state = c.memory && c.memory.state || CustomerState.NORMAL;
@@ -190,13 +185,13 @@ export function setupGame(){
       }
     };
     GameState.queue.forEach(c=>{
-      if(c.sprite){ c.sprite.setScale(scaleForY(c.sprite.y)); setDepth(c.sprite,5); }
+      if(c.sprite){ c.sprite.setScale(scaleForY(c.sprite.y)); setDepthFromBottom(c.sprite,5); }
       if(c.dog) scaleDog(c.dog);
       if(c.isDog) scaleDog(c.sprite);
       updateHeart(c);
     });
     GameState.wanderers.forEach(c=>{
-      if(c.sprite){ c.sprite.setScale(scaleForY(c.sprite.y)); setDepth(c.sprite,5); }
+      if(c.sprite){ c.sprite.setScale(scaleForY(c.sprite.y)); setDepthFromBottom(c.sprite,5); }
       if(c.dog) scaleDog(c.dog);
       if(c.isDog) scaleDog(c.sprite);
       updateHeart(c);
@@ -964,8 +959,7 @@ export function setupGame(){
       };
 
       const sprite=current.sprite;
-      const bottomY = sprite.y + sprite.displayHeight * (1 - sprite.originY);
-      sprite.setDepth(5 + bottomY*0.006);
+      setDepthFromBottom(sprite,5);
 
       // Remove the current customer from the queue
       GameState.queue.shift();

--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -93,4 +93,12 @@ export function blinkPriceBorder(text, scene, color="#fff", thickness=2){
   },[],scene);
 }
 
+// Calculate depth based on the bottom edge of a sprite.
+// This keeps layering consistent as objects move up and down.
+export function setDepthFromBottom(sprite, base = 5){
+  if(!sprite || !sprite.setDepth) return;
+  const bottomY = sprite.y + sprite.displayHeight * (1 - sprite.originY);
+  sprite.setDepth(base + bottomY * 0.006);
+}
+
 export { blinkButton as default };


### PR DESCRIPTION
## Summary
- share new `setDepthFromBottom` helper for consistent layering
- apply helper when spawning or moving customers and dogs
- replace ad-hoc depth logic with helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854127fdd68832fbce4aee1eebc21ad