### PR TITLE
Fix queue display and tests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { debugLog, DEBUG } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_Y, DIALOG_Y } from "./ui.js";
-import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel } from "./customers.js";
+import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, queueLimit } from "./customers.js";
 import { lureNextWanderer, moveQueueForward, scheduleNextSpawn, spawnCustomer } from './entities/customerQueue.js';
 import { baseConfig } from "./scene.js";
 import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from "./state.js";
@@ -216,11 +216,11 @@ export function setupGame(){
 
 
   function updateLevelDisplay(){
-    const newLevel=calcLoveLevel(GameState.love);
+    const newLength = queueLimit(GameState.love);
     if(queueLevelText){
-      queueLevelText.setText('Lv. '+newLevel);
-      queueLevelText.setVisible(newLevel>=2);
-      if(newLevel!==GameState.loveLevel && newLevel>=2){
+      queueLevelText.setText('Queue Length: '+newLength);
+      queueLevelText.setVisible(newLength>=2);
+      if(newLength!==GameState.loveLevel && newLength>=2){
         const sp=queueLevelText.scene.add.text(queueLevelText.x,queueLevelText.y,'✨',
             {font:'18px sans-serif',fill:'#000'})
           .setOrigin(0.5).setDepth(queueLevelText.depth+1);
@@ -228,7 +228,7 @@ export function setupGame(){
             duration:dur(600),onComplete:()=>sp.destroy()});
       }
     }
-    GameState.loveLevel=newLevel;
+    GameState.loveLevel=newLength;
       if(GameState.girlReady && queueLevelText && queueLevelText.scene){
         lureNextWanderer(queueLevelText.scene);
       }
@@ -295,7 +295,7 @@ export function setupGame(){
     loveText=this.add.text(20,50,'❤️ '+GameState.love,{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
     // Display level indicator on the left side of the order table so it doesn't
     // overlap the price ticket.
-    queueLevelText=this.add.text(156,316,'Lv. '+GameState.loveLevel,{font:'16px sans-serif',fill:'#000'})
+    queueLevelText=this.add.text(156,316,'Queue Length: '+queueLimit(GameState.love),{font:'16px sans-serif',fill:'#000'})
       .setOrigin(0.5).setDepth(1);
     updateLevelDisplay();
     // truck & girl

--- a/test/test.js
+++ b/test/test.js
@@ -615,6 +615,7 @@ function testAnimateLoveChange() {
     lureNextWanderer: () => {},
     animateStatChange: () => {},
     calcLoveLevel(v) { if (v >= 100) return 4; if (v >= 50) return 3; if (v >= 20) return 2; return 1; },
+    queueLimit(v) { return Math.floor(v / 10); },
     updateLevelDisplay: null,
     dur: v => v,
     fn: null,
@@ -624,7 +625,7 @@ function testAnimateLoveChange() {
   loadCustomerState(context);
   vm.createContext(context);
   vm.runInContext(
-    'updateLevelDisplay = function(){ const lvl = calcLoveLevel(love); queueLevelText.setText("Lv. " + lvl); queueLevelText.setVisible(lvl >= 2); loveLevel = lvl; };',
+    'updateLevelDisplay = function(){ const len = queueLimit(love); queueLevelText.setText("Queue Length: " + len); queueLevelText.setVisible(len >= 2); loveLevel = len; };',
     context
   );
   vm.runInContext(funcSrc + '\nfn=animateLoveChange;', context);
@@ -638,13 +639,13 @@ function testAnimateLoveChange() {
 
   animateLoveChange.call(scene, 1, cust);
   assert.strictEqual(context.love, 20, 'love not incremented');
-  assert.strictEqual(context.queueLevelText.text, 'Lv. 2', 'queue level up not reflected');
-  assert.strictEqual(context.queueLevelText.visible, true, 'queue level text should be visible');
+  assert.strictEqual(context.queueLevelText.text, 'Queue Length: 2', 'queue length up not reflected');
+  assert.strictEqual(context.queueLevelText.visible, true, 'queue length text should be visible');
 
   animateLoveChange.call(scene, -2, cust);
   assert.strictEqual(context.love, 18, 'love not decremented');
-  assert.strictEqual(context.queueLevelText.text, 'Lv. 1', 'queue level down not reflected');
-  assert.strictEqual(context.queueLevelText.visible, false, 'queue level text should hide');
+  assert.strictEqual(context.queueLevelText.text, 'Queue Length: 1', 'queue length down not reflected');
+  assert.strictEqual(context.queueLevelText.visible, false, 'queue length text should hide');
   console.log('animateLoveChange update test passed');
 }
 


### PR DESCRIPTION
## Summary
- show the queue capacity instead of "Lv" in the HUD
- update test harness for new queue length label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685415295044832faff1ce2fbb08df92