### PR TITLE
Fix queue growth

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -163,6 +163,12 @@ export function checkQueueSpacing(scene) {
     const dist = Phaser.Math.Distance.Between(cust.sprite.x, cust.sprite.y, tx, ty);
     if (dist > 2) {
       if (cust.walkTween) {
+        if (cust.walkTween.isPlaying) {
+          // Already moving toward the correct spot. Don't reset the tween,
+          // otherwise lureNextWanderer will keep aborting and the queue will
+          // never fill beyond two customers.
+          return;
+        }
         cust.walkTween.stop();
         cust.walkTween.remove();
         cust.walkTween = null;


### PR DESCRIPTION
## Summary
- avoid resetting customer movement when checking queue spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68541f2b7870832f90990e09d84d9533