### PR TITLE
Prevent dialog overlap while serving orders

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -539,6 +539,10 @@ export function setupGame(){
   }
 
   function showDialog(){
+    if (GameState.saleInProgress) {
+      // Defer showing the next order until the current sale animation finishes
+      return;
+    }
     if (typeof debugLog === 'function') {
       debugLog('showDialog start', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
     }
@@ -776,6 +780,9 @@ export function setupGame(){
 
   function handleAction(type){
     const current=GameState.activeCustomer;
+    if (current) {
+      GameState.saleInProgress = true;
+    }
     if ((type==='sell' || type==='give') && dialogDrinkEmoji && dialogPriceContainer && dialogPriceContainer.visible) {
       dialogDrinkEmoji.clearTint();
     }
@@ -906,6 +913,7 @@ export function setupGame(){
     GameState.activeCustomer=null;
 
     const finish=()=>{
+      GameState.saleInProgress = false;
       const exit=()=>{
         if(dialogDrinkEmoji && dialogDrinkEmoji.attachedTo === current.sprite){
           dialogDrinkEmoji.attachedTo = null;
@@ -1837,6 +1845,7 @@ export function setupGame(){
     Object.keys(GameState.customerMemory).forEach(k=>{ delete GameState.customerMemory[k]; });
     GameState.heartWin = null;
     GameState.servedCount=0;
+    GameState.saleInProgress = false;
     sideCAlpha=0;
     sideCFadeTween=null;
     GameState.gameOver=false;

--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,7 @@ export const GameState = {
   gameOver: false,
   loveLevel: 1,
   servedCount: 0,
+  saleInProgress: false,
   heartWin: null,
   girlReady: false,
   truck: null,


### PR DESCRIPTION
## Summary
- track when a sale animation is running
- defer new dialogs until the sale finishes
- reset the flag when restarting the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543f3c80a4832f9535dee90b824d4e