### PR TITLE
Fix mood emoji tracking for dog and owner when leaving

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -81,6 +81,15 @@ export function updateDog(owner) {
         dog.prevX = dog.x;
         const s = scaleForY(dog.y) * (dog.scaleFactor || 0.6);
         dog.setScale(s * (dog.dir || 1), s);
+        if (dog.heartEmoji) {
+          const hy = dog.y + dog.displayHeight * 0.30;
+          const hs = scaleForY(dog.y) * 0.8;
+          dog.heartEmoji
+            .setPosition(dog.x, hy)
+            .setScale(hs)
+            .setDepth(dog.depth + 1)
+            .setShadow(0, 0, '#000', 4);
+        }
       });
       tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); });
       dog.currentTween = tl;
@@ -161,6 +170,15 @@ export function updateDog(owner) {
       const s = scaleForY(t.y) * (t.scaleFactor || 0.6);
       t.setScale(s * (t.dir || 1), s);
       setDepthFromBottom(t, 3);
+      if (dog.heartEmoji) {
+        const hy = t.y + t.displayHeight * 0.30;
+        const hs = scaleForY(t.y) * 0.8;
+        dog.heartEmoji
+          .setPosition(t.x, hy)
+          .setScale(hs)
+          .setDepth(t.depth + 1)
+          .setShadow(0, 0, '#000', 4);
+      }
     },
     onComplete: () => {
       dog.currentTween = null;
@@ -194,6 +212,15 @@ export function sendDogOffscreen(dog, x, y) {
       const s = scaleForY(t.y) * (t.scaleFactor || 0.6);
       t.setScale(s * (t.dir || 1), s);
       setDepthFromBottom(t, 3);
+      if (dog.heartEmoji) {
+        const hy = t.y + t.displayHeight * 0.30;
+        const hs = scaleForY(t.y) * 0.8;
+        dog.heartEmoji
+          .setPosition(t.x, hy)
+          .setScale(hs)
+          .setDepth(t.depth + 1)
+          .setShadow(0, 0, '#000', 4);
+      }
     },
     onComplete: () => {
       if (dog.heartEmoji) {

--- a/src/main.js
+++ b/src/main.js
@@ -931,9 +931,14 @@ export function setupGame(){
           owner.exitY=targetY;
           current.exitX=owner.exitX;
           current.exitY=owner.exitY;
-          if(owner.heartEmoji){ owner.heartEmoji.destroy(); owner.heartEmoji=null; }
           this.tweens.add({targets:owner.sprite,y:targetY,duration:dur(6000),callbackScope:this,
-            onUpdate:(tw,t)=>{const p=tw.progress; t.x=startX+p*distanceX+Math.sin(p*Math.PI*freq)*amp; t.setScale(scaleForY(t.y));},
+            onUpdate:(tw,t)=>{const p=tw.progress; t.x=startX+p*distanceX+Math.sin(p*Math.PI*freq)*amp; t.setScale(scaleForY(t.y));
+              if(owner.heartEmoji){
+                const hy=t.y+t.displayHeight*0.30;
+                const hs=scaleForY(t.y)*0.8;
+                owner.heartEmoji.setPosition(t.x,hy).setScale(hs).setDepth(t.depth+1).setShadow(0,0,'#000',4);
+              }
+            },
             onComplete:owner.exitHandler});
           sendDogOffscreen.call(this,current.sprite,owner.exitX,owner.exitY);
           owner.dog = null;
@@ -1033,9 +1038,14 @@ export function setupGame(){
         owner.exitY=targetY;
         current.exitX=owner.exitX;
         current.exitY=owner.exitY;
-        if(owner.heartEmoji){ owner.heartEmoji.destroy(); owner.heartEmoji=null; }
         this.tweens.add({targets:owner.sprite,y:targetY,duration:dur(6000),callbackScope:this,
-          onUpdate:(tw,t)=>{const p=tw.progress; t.x=startX+p*distanceX+Math.sin(p*Math.PI*freq)*amp; t.setScale(scaleForY(t.y));},
+          onUpdate:(tw,t)=>{const p=tw.progress; t.x=startX+p*distanceX+Math.sin(p*Math.PI*freq)*amp; t.setScale(scaleForY(t.y));
+            if(owner.heartEmoji){
+              const hy=t.y+t.displayHeight*0.30;
+              const hs=scaleForY(t.y)*0.8;
+              owner.heartEmoji.setPosition(t.x,hy).setScale(hs).setDepth(t.depth+1).setShadow(0,0,'#000',4);
+            }
+          },
           onComplete:owner.exitHandler});
         sendDogOffscreen.call(this,current.sprite,current.exitX,current.exitY);
         return;


### PR DESCRIPTION
## Summary
- ensure dog heart emoji moves with dog during movement and exit
- keep owner's heart emoji visible while dog finishes order

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6854418d198c832f924fad5792ba02a6