### PR TITLE
Fix crash when dog heart emoji destroyed

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -81,12 +81,12 @@ export function updateDog(owner) {
         dog.prevX = dog.x;
         const s = scaleForY(dog.y) * (dog.scaleFactor || 0.6);
         dog.setScale(s * (dog.dir || 1), s);
-        if (dog.heartEmoji) {
-          const hy = dog.y + dog.displayHeight * 0.30;
-          const hs = scaleForY(dog.y) * 0.8;
-          dog.heartEmoji
-            .setPosition(dog.x, hy)
-            .setScale(hs)
+      if (dog.heartEmoji && dog.heartEmoji.scene) {
+        const hy = dog.y + dog.displayHeight * 0.30;
+        const hs = scaleForY(dog.y) * 0.8;
+        dog.heartEmoji
+          .setPosition(dog.x, hy)
+          .setScale(hs)
             .setDepth(dog.depth + 1)
             .setShadow(0, 0, '#000', 4);
         }
@@ -170,7 +170,7 @@ export function updateDog(owner) {
       const s = scaleForY(t.y) * (t.scaleFactor || 0.6);
       t.setScale(s * (t.dir || 1), s);
       setDepthFromBottom(t, 3);
-      if (dog.heartEmoji) {
+      if (dog.heartEmoji && dog.heartEmoji.scene) {
         const hy = t.y + t.displayHeight * 0.30;
         const hs = scaleForY(t.y) * 0.8;
         dog.heartEmoji
@@ -212,7 +212,7 @@ export function sendDogOffscreen(dog, x, y) {
       const s = scaleForY(t.y) * (t.scaleFactor || 0.6);
       t.setScale(s * (t.dir || 1), s);
       setDepthFromBottom(t, 3);
-      if (dog.heartEmoji) {
+      if (dog.heartEmoji && dog.heartEmoji.scene) {
         const hy = t.y + t.displayHeight * 0.30;
         const hs = scaleForY(t.y) * 0.8;
         dog.heartEmoji
@@ -223,7 +223,7 @@ export function sendDogOffscreen(dog, x, y) {
       }
     },
     onComplete: () => {
-      if (dog.heartEmoji) {
+      if (dog.heartEmoji && dog.heartEmoji.scene) {
         dog.heartEmoji.destroy();
         dog.heartEmoji = null;
       }


### PR DESCRIPTION
## Summary
- check that `dog.heartEmoji` is still part of the scene before updating it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545781cc74832fa1f767edf7e39938