### PR TITLE
Allow dogs to roam further

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -7,6 +7,8 @@ import { scatterSparrows } from '../sparrow.js';
 export const DOG_MIN_Y = ORDER_Y + 20;
 export const DOG_SPEED = 120; // base movement speed for the dog
 export const DOG_FAST_DISTANCE = 160; // accelerate when farther than this from owner
+export const DOG_ROAM_RADIUS = 120; // how far a dog can wander from its owner
+export const DOG_COUNTER_RADIUS = 40; // distance to maintain when owner is ordering
 export const DOG_TYPES = [
   // scale represents relative size compared to a customer sprite
   // all dogs are smaller; the largest is now the old "service" size
@@ -31,12 +33,13 @@ export function updateDog(owner) {
   if (!dog || !owner.sprite) return;
   const ms = owner.sprite;
   const dogDist = Phaser.Math.Distance.Between(dog.x, dog.y, ms.x, ms.y);
-  let radius = 80;
+  let radius = DOG_ROAM_RADIUS;
   let near = 60;
   let targetX = ms.x, targetY = ms.y;
   const type = dog.dogType || 'standard';
+  const atCounter = ms.x === ORDER_X && ms.y === ORDER_Y;
+  if (atCounter) radius = DOG_COUNTER_RADIUS;
   if (type === 'service') {
-    radius = 50;
     near = 30;
   }
   if (type === 'guide') {


### PR DESCRIPTION
## Summary
- dogs can wander further from their owners
- keep dogs close while their owner is ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545b39c728832f9ad7d1e7a4b9cae4