### PR TITLE
Improve dog pup cup ordering

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -67,9 +67,11 @@ export function updateDog(owner) {
     dog.currentTween.stop();
     dog.currentTween = null;
   }
-  if (type !== 'service' && !dog.excited) {
+  if (type !== 'service' && !dog.excited && !ordering) {
+    const otherDogs = others.filter(o => o.isDog);
+    const seenDog = otherDogs.find(o => Phaser.Math.Distance.Between(dog.x, dog.y, o.sprite.x, o.sprite.y) < 80);
     const seenBird = birds.find(b => Phaser.Math.Distance.Between(dog.x, dog.y, b.sprite.x, b.sprite.y) < 80);
-    const seen = seenBird || others.find(o => Phaser.Math.Distance.Between(dog.x, dog.y, o.sprite.x, o.sprite.y) < 80);
+    const seen = seenDog || seenBird;
     if (seen) {
       dog.excited = true;
       const s = seen.sprite;

--- a/src/main.js
+++ b/src/main.js
@@ -1013,6 +1013,10 @@ export function setupGame(){
 
       if(current.dogCustomer && !current.isDog){
         const dogCust = current.dogCustomer;
+        if(current.dog && current.dog.followEvent){
+          current.dog.followEvent.remove(false);
+          current.dog.followEvent = null;
+        }
         if(dogCust.followEvent){ dogCust.followEvent.remove(false); dogCust.followEvent=null; }
         dogCust.atOrder = false;
         dogCust.arrived = true;


### PR DESCRIPTION
## Summary
- keep dogs from wandering by removing `followEvent` when they're about to order
- dogs now notice nearby dogs when idle and play with them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685470dbb28c832fa02fab9dc17e8578