### PR TITLE
Improve price ticket placement and emojis

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -23,10 +23,14 @@ export function receipt(value){
 
 export function emojiFor(name){
   const n=name.toLowerCase();
-  if(n.includes('tea')) return '🍵';
-  if(n.includes('chocolate')) return '🍫';
-  if(n.includes('latte')||n.includes('mocha')||n.includes('espresso')) return '☕';
-  return '☕';
+  const iced = n.includes('iced') || n.includes('cold brew');
+  let base='☕';
+  if(n.includes('tea')) base='🍵';
+  else if(n.includes('chocolate')) base='🍫';
+  else if(n.includes('rose')) base='🌹';
+  else if(n.includes('pink')) base='🌸';
+  if(iced) return `🧊\n${base}`;
+  return base;
 }
 
 export function preload(){

--- a/src/main.js
+++ b/src/main.js
@@ -680,8 +680,8 @@ export function setupGame(){
     let bubbleColor = 0xffffff;
     drawDialogBubble(c.sprite.x, c.sprite.y, bubbleColor);
 
-    const priceTargetXDefault = dialogBg.x + dialogBg.width/2 - 40;
-    const priceTargetY = dialogBg.y - dialogBg.height - (c.isDog ? 30 : 0);
+    const priceTargetXDefault = dialogBg.x + dialogBg.width/2 - 30; // nudge right
+    const priceTargetY = dialogBg.y - dialogBg.height - 20 - (c.isDog ? 30 : 0);
     const ticketW = c.isDog ? dialogPriceBox.width : (dialogPriceTicket ? dialogPriceTicket.displayWidth : dialogPriceBox.width);
     const ticketOffset = ticketW/2 + 10;
     const girlRight = (typeof girl !== 'undefined' && girl) ?
@@ -740,7 +740,7 @@ export function setupGame(){
         .setAlpha(1);
       dialogDrinkEmoji
         .setText(emojiFor(c.orders[0].req))
-        .setPosition(0,-dialogPriceBox.height/4 + 5)
+        .setPosition(0,-dialogPriceBox.height/4 + 8) // slightly lower
         .setScale(2)
         .setVisible(true);
     }


### PR DESCRIPTION
## Summary
- nudge price ticket higher and to the right
- lower the order emoji slightly
- expand emoji mappings and add stacked emojis for iced drinks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68548144b888832faac7c9f55a7e99fb