### PR TITLE
Use PupCup asset for dog orders

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket','pupcup'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -41,6 +41,7 @@ export function preload(){
   loader.image('falcon_end','assets/ladyfalconend.png');
   loader.image('revolt_end','assets/revolt.png');
   loader.image('price_ticket','assets/priceticket.png');
+  loader.image('pupcup','assets/pupcup.png');
   loader.spritesheet('sparrow','assets/sparrow.png',{frameWidth:16,frameHeight:16});
   loader.spritesheet('sparrow2','assets/sparrow2.png',{frameWidth:20,frameHeight:20});
   loader.spritesheet('sparrow3','assets/sparrow3.png',{frameWidth:20,frameHeight:20});

--- a/src/main.js
+++ b/src/main.js
@@ -153,7 +153,7 @@ export function setupGame(){
   let moneyText, loveText, queueLevelText;
   let dialogBg, dialogText, dialogCoins,
       dialogPriceLabel, dialogPriceValue, dialogPriceBox,
-      dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket,
+      dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket, dialogPupCup,
       btnSell, btnGive, btnRef;
   let reportLine1, reportLine2, reportLine3, tipText;
   let paidStamp, lossStamp;
@@ -400,6 +400,9 @@ export function setupGame(){
     dialogPriceTicket=this.add.image(0,0,'price_ticket')
       .setOrigin(0.5)
       .setVisible(false);
+    dialogPupCup=this.add.image(0,0,'pupcup')
+      .setOrigin(0.5)
+      .setVisible(false);
 
     dialogPriceLabel=this.add.text(0,-15,'',{font:'14px sans-serif',fill:'#000',align:'center'})
       .setOrigin(0.5);
@@ -408,7 +411,7 @@ export function setupGame(){
     dialogDrinkEmoji=this.add.text(-30,-20,'',{font:'24px sans-serif'})
       .setOrigin(0.5);
 
-    dialogPriceContainer=this.add.container(0,0,[dialogPriceTicket, dialogPriceBox, dialogDrinkEmoji, dialogPriceLabel, dialogPriceValue])
+    dialogPriceContainer=this.add.container(0,0,[dialogPriceTicket, dialogPupCup, dialogPriceBox, dialogDrinkEmoji, dialogPriceLabel, dialogPriceValue])
       .setDepth(11)
       .setVisible(false);
 
@@ -680,6 +683,10 @@ export function setupGame(){
     let bubbleColor = 0xffffff;
     drawDialogBubble(c.sprite.x, c.sprite.y, bubbleColor);
 
+    if(c.isDog){
+      dialogPriceBox.width = dialogPupCup.displayWidth;
+      dialogPriceBox.height = dialogPupCup.displayHeight;
+    }
     const priceTargetXDefault = dialogBg.x + dialogBg.width/2 - 40;
     const priceTargetY = dialogBg.y - dialogBg.height - (c.isDog ? 30 : 0);
     const ticketW = c.isDog ? dialogPriceBox.width : (dialogPriceTicket ? dialogPriceTicket.displayWidth : dialogPriceBox.width);
@@ -701,30 +708,19 @@ export function setupGame(){
     dialogPriceContainer.alpha = 1;
     if(c.isDog){
       dialogPriceTicket.setVisible(false);
-      dialogPriceBox.setVisible(true);
-      resetPriceBox();
-      dialogPriceBox.width = 120;
-      dialogPriceBox.height = 80;
-      dialogPriceLabel
-        .setStyle({fontSize:'14px'})
-        .setText('Free')
-        .setOrigin(1,0)
-        .setPosition(dialogPriceBox.width/2-5, -dialogPriceBox.height/2+5)
-        .setVisible(true);
-      dialogPriceValue
-        .setStyle({fontSize:'24px'})
-        .setText('Pup Cup')
-        .setColor('#000')
-        .setOrigin(0.5)
-        .setPosition(0, 15)
-        .setScale(1)
-        .setAlpha(1);
+      dialogPupCup.setVisible(true);
+      dialogPriceBox.setVisible(false);
+      dialogPriceBox.width = dialogPupCup.displayWidth;
+      dialogPriceBox.height = dialogPupCup.displayHeight;
+      dialogPriceLabel.setVisible(false);
+      dialogPriceValue.setVisible(false);
       dialogDrinkEmoji
         .setText('🍨')
-        .setPosition(-dialogPriceBox.width/2+23,-dialogPriceBox.height/2+23)
-        .setScale(1.2)
+        .setPosition(0,-dialogPriceBox.height/4 + 5)
+        .setScale(2)
         .setVisible(true);
     } else {
+      dialogPupCup.setVisible(false);
       dialogPriceTicket.setVisible(true);
       dialogPriceBox.setVisible(false); // hide outline from old ticket
       dialogPriceBox.width = dialogPriceTicket.displayWidth;


### PR DESCRIPTION
## Summary
- load new `pupcup` asset
- display the `pupcup` image instead of the old free ticket
- keep the ice cream emoji when dogs order a Pup Cup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685482db9558832f96d281a7c610c8f5