### PR TITLE
Animate ticket total when tipped

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -79,6 +79,29 @@ export function setupGame(){
     },[],scene);
   }
 
+  function countPrice(text, scene, from, to, baseLeft, baseY=15){
+    if(!text || !scene) return;
+    const duration = dur(400);
+    if(scene.tweens && scene.tweens.addCounter){
+      scene.tweens.addCounter({
+        from,
+        to,
+        duration,
+        onUpdate:tween=>{
+          text.setText(receipt(tween.getValue()));
+          text.setPosition(baseLeft + text.displayWidth/2, baseY);
+        },
+        onComplete:()=>{
+          text.setText(receipt(to));
+          text.setPosition(baseLeft + text.displayWidth/2, baseY);
+        }
+      });
+    } else {
+      text.setText(receipt(to));
+      text.setPosition(baseLeft + text.displayWidth/2, baseY);
+    }
+  }
+
   function cleanupFloatingEmojis(){
     floatingEmojis.slice().forEach(e=>{
       if(e && e.destroy) e.destroy();
@@ -1176,7 +1199,7 @@ export function setupGame(){
       const baseLeft = t.x - t.displayWidth/2;
       t.setText(receipt(totalCost));
       t.setPosition(baseLeft + t.displayWidth/2, t.y);
-      emphasizePrice(t);
+      // Price border will blink; no additional flash needed
       const ticketH = dialogPriceBox.height;
       let centerX = ticket.x;
       let stampY = ticket.y;
@@ -1210,11 +1233,7 @@ export function setupGame(){
       }, [], this);
       t.setPosition(t.x, 15);
 
-      const flashPrice=()=>{
-        const oy=t.y;
-        this.tweens.add({targets:t,y:oy-30,duration:dur(100),yoyo:true});
-      };
-      flashPrice();
+      // Removed flashing movement of the price text
 
       let delay=dur(300);
       if(tip>0){
@@ -1235,12 +1254,9 @@ export function setupGame(){
             duration: dur(200),
             ease: 'Back.easeOut'
           });
-          t.setText(receipt(totalCost + tip));
-          t.setPosition(oldLeft + t.displayWidth/2, t.y);
-          emphasizePrice(t);
+          countPrice(t, this, totalCost, totalCost + tip, oldLeft);
           blinkPriceBorder(t, this, '#0f0', 6);
-          this.tweens.add({targets:t, scale:1.1, duration:dur(120), yoyo:true});
-          flashPrice();
+          // no scaling or flash animation for price text
         },[],this);
         delay+=dur(300);
       } else {


### PR DESCRIPTION
## Summary
- add `countPrice` helper to animate the ticket price
- stop flashing the price text and remove scaling
- animate the ticket total up to the new tipped value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854818d6874832f916e23e91ed97c1b