### PR TITLE
Fix dialog price target variable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -706,14 +706,20 @@ export function setupGame(){
     let bubbleColor = 0xffffff;
     drawDialogBubble(c.sprite.x, c.sprite.y, bubbleColor);
 
-    const priceTargetXDefault = dialogBg.x + dialogBg.width/2 - 30; // nudge right
-    const priceTargetY = dialogBg.y - dialogBg.height - 20 - (c.isDog ? 30 : 0);
 
-    const ticketW = c.isDog ? dialogPriceBox.width : (dialogPriceTicket ? dialogPriceTicket.displayWidth : dialogPriceBox.width);
-    const ticketOffset = ticketW/2 + 10;
-    const girlRight = (typeof girl !== 'undefined' && girl) ?
-      girl.x + girl.displayWidth/2 : dialogBg.x;
+    const ticketW = c.isDog
+      ? dialogPriceBox.width
+      : (dialogPriceTicket ? dialogPriceTicket.displayWidth : dialogPriceBox.width);
+    const ticketH = c.isDog
+      ? dialogPriceBox.height
+      : (dialogPriceTicket ? dialogPriceTicket.displayHeight : dialogPriceBox.height);
+    const ticketOffset = ticketW / 2 + 10;
 
+    const truckRef = (typeof truck !== 'undefined' && truck) ? truck : null;
+
+    const girlRight = (typeof girl !== 'undefined' && girl)
+      ? girl.x + girl.displayWidth / 2
+      : dialogBg.x;
     const minX = girlRight + ticketOffset;
 
     let priceTargetX;


### PR DESCRIPTION
## Summary
- remove duplicate declaration of `priceTargetY`
- restore missing `ticketH` and `truckRef` logic in dialog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685485a83928832f89e2a8e5ed417745