### PR TITLE
Remove queue limit text and add sparkle indicator

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -23,6 +23,16 @@ import { startWander, loopsForState } from './wanderers.js';
 import { DOG_TYPES, updateDog, scaleDog } from './dog.js';
 import { setDepthFromBottom } from '../ui/helpers.js';
 
+function sparkleQueueSpot(scene){
+  if(!scene) return;
+  const idx=GameState.queue.length;
+  const x=idx===0?ORDER_X:QUEUE_X-QUEUE_SPACING*(idx-1);
+  const y=idx===0?ORDER_Y:QUEUE_Y-QUEUE_OFFSET*(idx-1);
+  const sp=scene.add.text(x,y,'✨',{font:'18px sans-serif',fill:'#fff'})
+    .setOrigin(0.5).setDepth(20);
+  scene.tweens.add({targets:sp,alpha:0,yoyo:true,repeat:1,duration:dur(300),onComplete:()=>sp.destroy()});
+}
+
 
 // Slow down queue movement to match wander speed change
 const CUSTOMER_SPEED = 560 / 12;
@@ -77,6 +87,7 @@ export function lureNextWanderer(scene, specific) {
   }
 
   if (GameState.wanderers.length && GameState.queue.length < queueLimit()) {
+    sparkleQueueSpot(scene);
     if (GameState.queue.some((c, i) => i > 0 && c.walkTween && c.walkTween.isPlaying)) {
       if (typeof debugLog === 'function') {
         debugLog('lureNextWanderer abort: walkTween active');

--- a/src/main.js
+++ b/src/main.js
@@ -256,8 +256,6 @@ export function setupGame(){
   function updateLevelDisplay(){
     const newLength = queueLimit(GameState.love);
     if(queueLevelText){
-      queueLevelText.setText('Queue Length: '+newLength);
-      queueLevelText.setVisible(newLength>=2);
       if(newLength!==GameState.loveLevel && newLength>=2){
         const sp=queueLevelText.scene.add.text(queueLevelText.x,queueLevelText.y,'✨',
             {font:'18px sans-serif',fill:'#000'})
@@ -331,10 +329,9 @@ export function setupGame(){
     // HUD
     moneyText=this.add.text(20,20,'🪙 '+receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
     loveText=this.add.text(20,50,'❤️ '+GameState.love,{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
-    // Display level indicator on the left side of the order table so it doesn't
-    // overlap the price ticket.
-    queueLevelText=this.add.text(156,316,'Queue Length: '+queueLimit(GameState.love),{font:'16px sans-serif',fill:'#000'})
-      .setOrigin(0.5).setDepth(1);
+    // Indicator for available queue slots
+    queueLevelText=this.add.text(156,316,'',{font:'16px sans-serif',fill:'#000'})
+      .setOrigin(0.5).setDepth(1).setVisible(false);
     updateLevelDisplay();
     // truck & girl
     const startX=this.scale.width+100;

--- a/test/test.js
+++ b/test/test.js
@@ -625,7 +625,7 @@ function testAnimateLoveChange() {
   loadCustomerState(context);
   vm.createContext(context);
   vm.runInContext(
-    'updateLevelDisplay = function(){ const len = queueLimit(love); queueLevelText.setText("Queue Length: " + len); queueLevelText.setVisible(len >= 2); loveLevel = len; };',
+    'updateLevelDisplay = function(){ const len = queueLimit(love); if(len!==loveLevel && len>=2){ const sp=queueLevelText.scene.add.text(queueLevelText.x,queueLevelText.y,"✨",{font:"18px sans-serif",fill:"#000"}).setOrigin(0.5).setDepth(queueLevelText.depth+1); queueLevelText.scene.tweens.add({targets:sp,y:queueLevelText.y-20,alpha:0,duration:dur(600),onComplete:()=>sp.destroy()}); } loveLevel=len; };',
     context
   );
   vm.runInContext(funcSrc + '\nfn=animateLoveChange;', context);
@@ -639,13 +639,11 @@ function testAnimateLoveChange() {
 
   animateLoveChange.call(scene, 1, cust);
   assert.strictEqual(context.love, 20, 'love not incremented');
-  assert.strictEqual(context.queueLevelText.text, 'Queue Length: 2', 'queue length up not reflected');
-  assert.strictEqual(context.queueLevelText.visible, true, 'queue length text should be visible');
+  assert.strictEqual(context.queueLevelText.text, '', 'queue text should stay empty');
 
   animateLoveChange.call(scene, -2, cust);
   assert.strictEqual(context.love, 18, 'love not decremented');
-  assert.strictEqual(context.queueLevelText.text, 'Queue Length: 1', 'queue length down not reflected');
-  assert.strictEqual(context.queueLevelText.visible, false, 'queue length text should hide');
+  assert.strictEqual(context.queueLevelText.text, '', 'queue text should remain empty');
   console.log('animateLoveChange update test passed');
 }
 


### PR DESCRIPTION
## Summary
- remove queue length text display
- show sparkling emoji when a new queue slot opens
- adjust unit tests for new indicator behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685497d82750832f8cec422986132176