### PR TITLE
Adjust price ticket style

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -767,13 +767,13 @@ export function setupGame(){
       dialogPriceBox.height = dialogPriceTicket.displayHeight;
       dialogPriceLabel.setVisible(false); // remove "Total Cost" text
       dialogPriceValue
-        .setStyle({fontSize:'30px'})
+        .setStyle({fontSize:'42px'})
         .setText(receipt(totalCost))
-        .setColor('#000')
+        .setColor('#006400')
         .setOrigin(0.5)
         .setScale(1)
         .setAlpha(1);
-      priceValueYOffset = dialogPriceBox.height/2 - 24;
+      priceValueYOffset = dialogPriceBox.height/2 - 34;
       const orderEmoji = emojiFor(c.orders[0].req);
       dialogPriceValue.setPosition(0, priceValueYOffset);
       dialogDrinkEmoji
@@ -836,7 +836,7 @@ export function setupGame(){
       dialogText.setVisible(false);
       dialogCoins.setVisible(false);
       dialogPriceContainer.setVisible(false);
-      dialogPriceValue.setColor('#000').setStyle({fontStyle:'', strokeThickness:0});
+      dialogPriceValue.setColor('#006400').setStyle({fontStyle:'', strokeThickness:0});
     }else{
       dialogBg.setVisible(true);
       dialogText.setVisible(false);


### PR DESCRIPTION
## Summary
- make the price text on the ticket larger
- color the ticket price text dark green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549c33a1f0832f892634d53f94834f