### PR TITLE
Remove green flashing on price

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ When you choose to sell or give a drink, the button briefly blinks.
 After the animation finishes, the button automatically becomes
 clickable again so you can quickly serve the next customer.
 
+The price text used to flash green when a sale completed. That effect
+has been removed so the amount simply updates without flashing.
+
 ## Menu
 
 Customers can now order any of the following drinks:

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { CustomerState } from './constants.js';
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows } from './sparrow.js';
 import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
-import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, blinkPriceBorder, setDepthFromBottom } from './ui/helpers.js';
+import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, setDepthFromBottom } from './ui/helpers.js';
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { showStartScreen, playIntro } from './intro.js';
 
@@ -1253,7 +1253,7 @@ export function setupGame(){
           dialogPriceValue.setPosition(m.tx, m.ty);
         }
         t.setDepth(paidStamp.depth + 1);
-        blinkPriceBorder(t, this, '#0f0', 6);
+        // Removed blinkPriceBorder; no need to flash the price text
       }, [], this);
       // Removed flashing movement of the price text
 
@@ -1277,7 +1277,7 @@ export function setupGame(){
             ease: 'Back.easeOut'
           });
           countPrice(t, this, totalCost, totalCost + tip, oldLeft, t.y);
-          blinkPriceBorder(t, this, '#0f0', 6);
+          // Removed blinkPriceBorder; price text stays static
           // no scaling or flash animation for price text
         },[],this);
         delay+=dur(300);


### PR DESCRIPTION
## Summary
- stop flashing the price text when a sale completes
- document that price no longer flashes on sale

## Testing
- `npm run test:unit`
- `npm test` *(fails: OutgoingMessage.prototype._headers deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68549f63d934832f94dd096a841bcf68