### PR TITLE
Remove price outline when giving items

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { CustomerState } from './constants.js';
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows } from './sparrow.js';
 import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
-import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, blinkPriceBorder, setDepthFromBottom } from './ui/helpers.js';
+import { flashBorder, flashFill, blinkButton, applyRandomSkew, blinkPriceBorder, setDepthFromBottom } from './ui/helpers.js';
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { showStartScreen, playIntro } from './intro.js';
 
@@ -1332,8 +1332,8 @@ export function setupGame(){
       } else {
         t.setVisible(true)
           // start below the stamp so the stamp animation appears on top
-          .setDepth(lossStamp.depth-1);
-        emphasizePrice(t);
+          .setDepth(lossStamp.depth-1)
+          .setStyle({fontStyle:'bold', strokeThickness:0});
         const stampX=ticket.x + Phaser.Math.Between(-5,5);
         const stampY=ticket.y + Phaser.Math.Between(-5,5);
         const randFloat3 = Phaser.Math.FloatBetween || ((a,b)=>Phaser.Math.Between(a*1000,b*1000)/1000);


### PR DESCRIPTION
## Summary
- don't outline the price text when giving items away

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549e9257c4832f81ff9ceb011105f5