### PR TITLE
Add canvas-friendly grayscale effect

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows } from './sparrow
 import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
 
-import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, setDepthFromBottom } from './ui/helpers.js';
+import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, setDepthFromBottom, createGrayscaleTexture } from './ui/helpers.js';
 
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { showStartScreen, playIntro } from './intro.js';
@@ -437,6 +437,7 @@ export function setupGame(){
     .setOrigin(0.5)
     .setScale(1.25)
     .setVisible(false);
+  createGrayscaleTexture(this, 'price_ticket', 'price_ticket_gray');
   dialogPupCup=this.add.image(0,0,'pupcup')
     .setOrigin(0.5)
     .setScale(0.8)
@@ -596,8 +597,11 @@ export function setupGame(){
       dialogPriceBox.setStrokeStyle(2,0x000000);
     }
     dialogPriceBox.fillAlpha = 1;
-    if (dialogPriceTicket && dialogPriceTicket.clearTint) {
-      dialogPriceTicket.clearTint();
+    if(dialogPriceTicket){
+      if(dialogPriceTicket.clearTint) dialogPriceTicket.clearTint();
+      if(dialogPriceTicket.setTexture && this.textures.exists('price_ticket')){
+        dialogPriceTicket.setTexture('price_ticket');
+      }
     }
   }
 
@@ -1395,8 +1399,12 @@ export function setupGame(){
           .setVisible(true);
         skewFn2(lossStamp);
         // Ticket turns grayscale while the price flashes red
-        if (dialogPriceTicket && dialogPriceTicket.setTint) {
-          dialogPriceTicket.setTint(0x808080);
+        if(dialogPriceTicket){
+          if(this.game.renderer.type === Phaser.WEBGL && dialogPriceTicket.setTint){
+            dialogPriceTicket.setTint(0x808080);
+          }else if(dialogPriceTicket.setTexture && this.textures.exists('price_ticket_gray')){
+            dialogPriceTicket.setTexture('price_ticket_gray');
+          }
         }
         if (dialogPriceValue && dialogPriceValue.setColor) {
           dialogPriceValue.setColor('#ff0000');

--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -101,4 +101,25 @@ export function setDepthFromBottom(sprite, base = 5){
   sprite.setDepth(base + bottomY * 0.006);
 }
 
+export function createGrayscaleTexture(scene, key, destKey){
+  if(!scene || !scene.textures || !scene.textures.exists(key)) return;
+  const srcImg = scene.textures.get(key).getSourceImage();
+  if(!srcImg) return;
+  const w = srcImg.width;
+  const h = srcImg.height;
+  const canvasTex = scene.textures.createCanvas(destKey, w, h);
+  const ctx = canvasTex.getContext();
+  ctx.drawImage(srcImg, 0, 0);
+  const imgData = ctx.getImageData(0, 0, w, h);
+  const data = imgData.data;
+  for(let i=0;i<data.length;i+=4){
+    const r=data[i], g=data[i+1], b=data[i+2];
+    const gray=Math.round(0.299*r + 0.587*g + 0.114*b);
+    data[i]=data[i+1]=data[i+2]=gray;
+  }
+  ctx.putImageData(imgData, 0, 0);
+  canvasTex.refresh();
+  return canvasTex;
+}
+
 export { blinkButton as default };


### PR DESCRIPTION
## Summary
- add `createGrayscaleTexture` helper for canvas rendering
- precompute grayscale ticket texture in create()
- swap ticket texture when giving if canvas renderer is used
- restore original ticket texture in `resetPriceBox`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854a34bc1c4832f9d0698701739ab6c