### PR TITLE
Fix resetPriceBox context error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -893,7 +893,7 @@ export function setupGame(){
     }else{
       dialogDrinkEmoji.setVisible(true);
     }
-    resetPriceBox();
+    resetPriceBox.call(this);
     btnSell.setVisible(false);
     if (btnSell.input) btnSell.input.enabled = false;
     btnGive.setVisible(false);


### PR DESCRIPTION
## Summary
- ensure `resetPriceBox` runs with scene context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854a6946544832f9d115cd1eba9a8e5