### PR TITLE
Fix price display after dog orders

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -808,7 +808,8 @@ export function setupGame(){
         .setColor('#006400')
         .setOrigin(0.5)
         .setScale(0.9)
-        .setAlpha(1);
+        .setAlpha(1)
+        .setVisible(true);
       priceValueYOffset = dialogPriceBox.height/2 - 34;
       const orderEmoji = emojiFor(c.orders[0].req);
       dialogPriceValue.setPosition(-5, priceValueYOffset + 5);


### PR DESCRIPTION
## Summary
- ensure price value becomes visible again when showing price ticket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854aa8823ac832fa7d809bd0100589f