### PR TITLE
Change price text to white when stamped SOLD

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1336,6 +1336,7 @@ export function setupGame(){
           dialogPriceValue.setPosition(m.tx, m.ty);
         }
         t.setDepth(paidStamp.depth + 1);
+        t.setColor('#fff');
         // Removed blinkPriceBorder; no need to flash the price text
       }, [], this);
       // Removed flashing movement of the price text


### PR DESCRIPTION
## Summary
- update sale animation to set price text to white after the SOLD stamp lands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ac7281d4832f9aa7a92ee532295c