### PR TITLE
Restore PupCup emoji

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -791,9 +791,10 @@ export function setupGame(){
       dialogPriceLabel.setVisible(false);
       dialogPriceValue.setVisible(false);
       dialogDrinkEmoji
-
-        .setText('')
-        .setVisible(false);
+        .setText('🍨')
+        .setPosition(0,-dialogPriceBox.height/4 + 5)
+        .setScale(2)
+        .setVisible(true);
 
     } else {
       dialogPupCup.setVisible(false);


### PR DESCRIPTION
## Summary
- show the dessert emoji again when displaying the PupCup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854ac9d6ee4832f93c55f58a09f9822