### PR TITLE
Improve emoji display

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -24,9 +24,15 @@ export function receipt(value){
 export function emojiFor(name){
   const n = name.toLowerCase();
   const iced = n.includes('iced') || n.includes('cold brew');
-  const chocolate = n.includes('chocolate');
+  const chocolate = n.includes('chocolate') || n.includes('mocha');
+  const latte = n.includes('latte') || n.includes('cappuccino');
+  const espresso = n.includes('espresso');
   const rose = n.includes('rose');
   const pink = n.includes('pink');
+  const starry = n.includes('starry night');
+  const falcon = n.includes('falcon');
+  const roast = n.includes('roaster');
+  const crush = n.includes('crush');
   const tea = n.includes('tea');
 
   // Base drink emoji: coffee by default, tea cup when mentioned explicitly.
@@ -35,14 +41,20 @@ export function emojiFor(name){
   else if (n.includes('hot chocolate')) base = '🍫';
 
   const extras = [];
-  // Add modifiers below, leaving iced last so it appears on top
+  // Build extra modifiers. Order roughly controls layering.
+  if (falcon) extras.push('🦅');
+  if (roast) extras.push('🔥');
+  if (espresso) extras.push('⚡');
+  if (latte && base === '☕') extras.push('🥛');
   if (chocolate && base === '☕') extras.push('🍫');
+  if (starry) extras.push('✨');
   if (rose) extras.push('🌹');
   else if (pink) extras.push('🌸');
+  if (crush) extras.push('💥');
   if (iced) extras.push('🧊🧊');
 
   if (extras.length) {
-    return `${extras.join('')}\n${base}`;
+    return `${extras.join(' ')}\n${base}`;
   }
   return base;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -448,20 +448,44 @@ export function setupGame(){
     dialogPriceValue=this.add.text(-5,20,'',{font:'40px sans-serif',fill:'#000'})
       .setOrigin(0.5);
     const baseEmoji = this.add.text(0,0,'',{font:'24px sans-serif'}).setOrigin(0.5);
-    const extrasEmoji = this.add.text(0,-18,'',{font:'16px sans-serif'}).setOrigin(0.5);
-    dialogDrinkEmoji=this.add.container(-30,-20,[extrasEmoji, baseEmoji]);
+    const extra1 = this.add.text(0,-18,'',{font:'16px sans-serif'}).setOrigin(0.5);
+    const extra2 = this.add.text(0,-18,'',{font:'16px sans-serif'}).setOrigin(0.5);
+    const extra3 = this.add.text(0,-18,'',{font:'16px sans-serif'}).setOrigin(0.5);
+    dialogDrinkEmoji=this.add.container(-30,-20,[extra1, extra2, extra3, baseEmoji]);
     dialogDrinkEmoji.base = baseEmoji;
-    dialogDrinkEmoji.extras = extrasEmoji;
+    dialogDrinkEmoji.extras = [extra1, extra2, extra3];
     dialogDrinkEmoji.setText = function(str){
       const parts = String(str||'').split('\n');
-      this.base.setText(parts.pop()||'');
-      this.extras.setText(parts.join('\n'));
+      const base = parts.pop() || '';
+      const extras = parts.join(' ').trim().split(/\s+/).filter(Boolean).slice(0,3);
+      this.base.setText(base);
+      this.extras.forEach((e,i)=>{
+        if(extras[i]){
+          e.setText(extras[i]).setVisible(true);
+        }else{
+          e.setText('').setVisible(false);
+        }
+      });
+
+      const count = extras.length;
+      const baseY = count ? 6 : 0;
+      this.base.setPosition(0, baseY).setScale(count ? 0.9 : 1.1);
+      if(count===1){
+        this.extras[0].setScale(0.5).setPosition(0, baseY-18);
+      }else if(count===2){
+        this.extras[0].setScale(0.25).setPosition(-8, baseY-18);
+        this.extras[1].setScale(0.25).setPosition(8, baseY-18);
+      }else if(count>=3){
+        this.extras[0].setScale(0.25).setPosition(-8, baseY-16);
+        this.extras[1].setScale(0.25).setPosition(8, baseY-16);
+        this.extras[2].setScale(0.25).setPosition(0, baseY-28);
+      }
       return this;
     };
     dialogDrinkEmoji.setLineSpacing = ()=>dialogDrinkEmoji;
     dialogDrinkEmoji.clearTint = function(){
       if(this.base.clearTint) this.base.clearTint();
-      if(this.extras.clearTint) this.extras.clearTint();
+      this.extras.forEach(e=>{ if(e.clearTint) e.clearTint(); });
       return this;
     };
 

--- a/test/test.js
+++ b/test/test.js
@@ -959,7 +959,7 @@ function testEmojiFor() {
   vm.runInContext(src + '\nfn=emojiFor;', context);
   const emojiFor = context.fn;
 
-  assert.strictEqual(emojiFor('Iced Mocha'), '🍫🧊🧊\n☕', 'iced mocha emoji');
+  assert.strictEqual(emojiFor('Iced Mocha'), '🍫 🧊🧊\n☕', 'iced mocha emoji');
   assert.strictEqual(emojiFor('Rose Tea'), '🌹\n🍵', 'rose tea emoji');
   assert.strictEqual(emojiFor('Hot Chocolate'), '🍫', 'hot chocolate emoji');
   console.log('emojiFor test passed');


### PR DESCRIPTION
## Summary
- rework drink emoji container logic to handle up to three extras
- give each drink style unique extra emojis
- adjust tests for new `emojiFor` output

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854aa439118832f9c6a3353e187def9