### PR TITLE
Fix sale price text color

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1370,7 +1370,8 @@ export function setupGame(){
           dialogPriceValue.setPosition(m.tx, m.ty);
         }
         t.setDepth(paidStamp.depth + 1);
-        t.setColor('#fff');
+        // Keep the price text green after the sale
+        t.setColor('#006400');
         // Removed blinkPriceBorder; no need to flash the price text
       }, [], this);
       // Removed flashing movement of the price text


### PR DESCRIPTION
## Summary
- keep price text green when a sale completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854af24db80832f8613e2684eb6d2a8