### PR TITLE
Update action buttons to new graphics

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket','pupcup'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket','pupcup','give','refuse','sell'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -72,6 +72,9 @@ export function preload(){
   loader.image('revolt_end','assets/revolt.png');
   loader.image('price_ticket','assets/priceticket.png');
   loader.image('pupcup','assets/pupcup.png');
+  loader.image('give','assets/give.png');
+  loader.image('refuse','assets/refuse.png');
+  loader.image('sell','assets/sell.png');
   loader.spritesheet('sparrow','assets/sparrow.png',{frameWidth:16,frameHeight:16});
   loader.spritesheet('sparrow2','assets/sparrow2.png',{frameWidth:20,frameHeight:20});
   loader.spritesheet('sparrow3','assets/sparrow3.png',{frameWidth:20,frameHeight:20});

--- a/src/main.js
+++ b/src/main.js
@@ -533,29 +533,12 @@ export function setupGame(){
     // caused the total cost to appear in the dialog bubble.
 
 
-    // helper to create a rounded rectangle button with consistent sizing
-    const createButton=(x,label,iconChar,iconSize,color,handler,width=BUTTON_WIDTH,height=BUTTON_HEIGHT)=>{
-      const radius=8;
-      const g=this.add.graphics();
-      // Graphics objects do not support setShadow. Draw a simple shadow
-      // manually by rendering a darker rect slightly offset behind the button.
-      g.fillStyle(0x000000,0.3);
-      g.fillRoundedRect(-width/2+2,-height/2+2,width,height,radius);
-
-      g.fillStyle(color,1);
-      g.fillRoundedRect(-width/2,-height/2,width,height,radius);
-      let t=this.add.text(-width/2+10,0,label,{font:'20px sans-serif',fill:'#fff'})
-        .setOrigin(0,0.5);
-      let icon=this.add.text(width/2-10,0,iconChar,{font:`${iconSize}px sans-serif`,fill:'#fff'})
-        .setOrigin(1,0.5);
-      let children=[g,t,icon];
-      if(label==='REFUSE'){
-        t.setFontSize(18);
-        icon.setX(width/2-4);
-        children=[g,icon,t];
-      }
-      // position the button slightly lower so it peeks out of the dialog box
-      const c=this.add.container(x,BUTTON_Y,children)
+    // helper to create a button using an image asset
+    const createButton=(x,key,handler)=>{
+      const img=this.add.image(0,0,key);
+      const width=img.width;
+      const height=img.height;
+      const c=this.add.container(x,BUTTON_Y,[img])
         .setSize(width,height)
         .setDepth(12)
         .setVisible(false);
@@ -570,12 +553,9 @@ export function setupGame(){
     // buttons evenly spaced
 
     // Arrange buttons: Refuse on the left, Sell in the middle (largest), Give on the right
-    btnRef=createButton(80,'REFUSE','✋',32,0x800000,()=>handleAction.call(this,'refuse'));
-    // Make the Sell button wider so it stands out
-    btnSell=createButton(240,'SELL','💵',36,0x006400,()=>handleAction.call(this,'sell'), BUTTON_WIDTH*1.3, BUTTON_HEIGHT);
-    // The "Give" button should stand out from the sell/refuse buttons. Use a
-    // softer pastel pink so it is noticeable without being overwhelming.
-    btnGive=createButton(400,'GIVE','💝',28,0xffb6c1,()=>handleAction.call(this,'give'));
+    btnRef=createButton(80,'refuse',()=>handleAction.call(this,'refuse'));
+    btnSell=createButton(240,'sell',()=>handleAction.call(this,'sell'));
+    btnGive=createButton(400,'give',()=>handleAction.call(this,'give'));
 
 
     // sliding report texts


### PR DESCRIPTION
## Summary
- load new Give, Refuse and Sell button images
- switch button creation to use these image assets instead of drawn rectangles

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854b8125520832fb621023a951ac085