### PR TITLE
Use PupCup2 and swap to original on give

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket','pupcup','give','refuse','sell'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -72,6 +72,7 @@ export function preload(){
   loader.image('revolt_end','assets/revolt.png');
   loader.image('price_ticket','assets/priceticket.png');
   loader.image('pupcup','assets/pupcup.png');
+  loader.image('pupcup2','assets/pupcup2.png');
   loader.image('give','assets/give.png');
   loader.image('refuse','assets/refuse.png');
   loader.image('sell','assets/sell.png');

--- a/src/main.js
+++ b/src/main.js
@@ -438,7 +438,7 @@ export function setupGame(){
     .setScale(1.25)
     .setVisible(false);
   createGrayscaleTexture(this, 'price_ticket', 'price_ticket_gray');
-  dialogPupCup=this.add.image(0,0,'pupcup')
+  dialogPupCup=this.add.image(0,0,'pupcup2')
     .setOrigin(0.5)
     .setScale(0.8)
     .setVisible(false);
@@ -818,6 +818,7 @@ export function setupGame(){
     dialogPriceContainer.alpha = 1;
     if(c.isDog){
       dialogPriceTicket.setVisible(false);
+      dialogPupCup.setTexture('pupcup2');
       dialogPupCup.setVisible(true);
       dialogPriceBox.setVisible(false);
       dialogPriceBox.width = dialogPupCup.displayWidth;
@@ -984,6 +985,9 @@ export function setupGame(){
     const current=GameState.activeCustomer;
     if (current) {
       GameState.saleInProgress = true;
+    }
+    if(type==='give' && current && current.isDog && dialogPupCup){
+      dialogPupCup.setTexture('pupcup');
     }
     if ((type==='sell' || type==='give') && dialogDrinkEmoji && dialogPriceContainer && dialogPriceContainer.visible) {
       dialogDrinkEmoji.clearTint();


### PR DESCRIPTION
## Summary
- add new `pupcup2` asset in the loader and required list
- start dog orders with the `pupcup2` image
- when the Give button is pressed, swap the pup cup texture back to the original `pupcup`

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ba990824832fa01e285c5c2cb360