### PR TITLE
Shrink drink emoji after landing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -977,6 +977,22 @@ export function setupGame(){
       ease: 'Cubic.easeIn',
       onComplete: () => {
         dialogDrinkEmoji.attachedTo = target;
+        if (this.time && this.tweens) {
+          this.time.delayedCall(dur(100), () => {
+            this.tweens.add({
+              targets: dialogDrinkEmoji,
+              scale: 0,
+              alpha: 0,
+              duration: dur(100),
+              onComplete: () => {
+                dialogDrinkEmoji.attachedTo = null;
+                dialogDrinkEmoji.setVisible(false);
+                dialogDrinkEmoji.setScale(1);
+                dialogDrinkEmoji.setAlpha(1);
+              }
+            });
+          }, [], this);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- make drink emoji shrink and disappear 0.1s after landing on a customer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854bbd9cbf0832fb03cf4c97b91813b