### PR TITLE
Fix emoji depth

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -131,8 +131,8 @@ export function updateDog(owner) {
         dog.heartEmoji
           .setPosition(dog.x, hy)
           .setScale(hs)
-            .setDepth(dog.depth + 1)
-            .setShadow(0, 0, '#000', 4);
+          .setDepth(dog.depth)
+          .setShadow(0, 0, '#000', 4);
         }
       });
       tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); });
@@ -220,7 +220,7 @@ export function updateDog(owner) {
         dog.heartEmoji
           .setPosition(t.x, hy)
           .setScale(hs)
-          .setDepth(t.depth + 1)
+          .setDepth(t.depth)
           .setShadow(0, 0, '#000', 4);
       }
     },
@@ -262,7 +262,7 @@ export function sendDogOffscreen(dog, x, y) {
         dog.heartEmoji
           .setPosition(t.x, hy)
           .setScale(hs)
-          .setDepth(t.depth + 1)
+          .setDepth(t.depth)
           .setShadow(0, 0, '#000', 4);
       }
     },

--- a/src/main.js
+++ b/src/main.js
@@ -243,8 +243,12 @@ export function setupGame(){
         if(c.heartEmoji && c.heartEmoji.scene && c.heartEmoji.active){
           const y = c.sprite.y + c.sprite.displayHeight * 0.30;
           const scale = scaleForY(c.sprite.y)*0.8;
-          c.heartEmoji.setText(HEART_EMOJIS[state] || '').setPosition(c.sprite.x, y).setScale(scale).setShadow(0, 0, '#000', 4);
-          c.heartEmoji.setDepth(c.sprite.depth+1);
+          c.heartEmoji
+            .setText(HEART_EMOJIS[state] || '')
+            .setPosition(c.sprite.x, y)
+            .setScale(scale)
+            .setShadow(0, 0, '#000', 4)
+            .setDepth(c.sprite.depth);
           if(c.isDog){
             c.sprite.heartEmoji = c.heartEmoji;
           }
@@ -1133,10 +1137,15 @@ export function setupGame(){
     if(memory.state !== CustomerState.NORMAL && current.sprite){
       const hy = current.sprite.y + current.sprite.displayHeight * 0.30;
       const hs = scaleForY(current.sprite.y) * 0.8;
-      current.heartEmoji = current.sprite.scene.add.text(current.sprite.x, hy, HEART_EMOJIS[memory.state]||'',{font:'28px sans-serif'})
+      current.heartEmoji = current.sprite.scene.add.text(
+        current.sprite.x,
+        hy,
+        HEART_EMOJIS[memory.state] || '',
+        { font: '28px sans-serif' }
+      )
         .setOrigin(0.5)
         .setScale(hs)
-        .setDepth(current.sprite.depth+1)
+        .setDepth(current.sprite.depth)
         .setShadow(0, 0, '#000', 4);
     }
 
@@ -1203,7 +1212,11 @@ export function setupGame(){
               if(owner.heartEmoji && owner.heartEmoji.scene && owner.heartEmoji.active){
                 const hy=t.y+t.displayHeight*0.30;
                 const hs=scaleForY(t.y)*0.8;
-                owner.heartEmoji.setPosition(t.x,hy).setScale(hs).setDepth(t.depth+1).setShadow(0,0,'#000',4);
+                owner.heartEmoji
+                  .setPosition(t.x, hy)
+                  .setScale(hs)
+                  .setDepth(t.depth)
+                  .setShadow(0, 0, '#000', 4);
               }
             },
             onComplete:owner.exitHandler});
@@ -1277,7 +1290,7 @@ export function setupGame(){
               current.heartEmoji
                 .setPosition(t.x, hy)
                 .setScale(hs)
-                .setDepth(t.depth + 1)
+                .setDepth(t.depth)
                 .setShadow(0, 0, '#000', 4);
             }
           }
@@ -1317,7 +1330,11 @@ export function setupGame(){
             if(owner.heartEmoji && owner.heartEmoji.scene && owner.heartEmoji.active){
               const hy=t.y+t.displayHeight*0.30;
               const hs=scaleForY(t.y)*0.8;
-              owner.heartEmoji.setPosition(t.x,hy).setScale(hs).setDepth(t.depth+1).setShadow(0,0,'#000',4);
+              owner.heartEmoji
+                .setPosition(t.x, hy)
+                .setScale(hs)
+                .setDepth(t.depth)
+                .setShadow(0, 0, '#000', 4);
             }
           },
           onComplete:owner.exitHandler});
@@ -1346,7 +1363,11 @@ export function setupGame(){
             if(current.heartEmoji && current.heartEmoji.scene && current.heartEmoji.active){
               const hy = t.y + t.displayHeight * 0.30;
               const hs = scaleForY(t.y) * 0.8;
-              current.heartEmoji.setPosition(t.x, hy).setScale(hs).setDepth(t.depth+1).setShadow(0, 0, '#000', 4);
+              current.heartEmoji
+                .setPosition(t.x, hy)
+                .setScale(hs)
+                .setDepth(t.depth)
+                .setShadow(0, 0, '#000', 4);
             }
           },
           onComplete: exit
@@ -1365,7 +1386,11 @@ export function setupGame(){
             if(current.heartEmoji && current.heartEmoji.scene && current.heartEmoji.active){
               const hy = t.y + t.displayHeight * 0.30;
               const hs = scaleForY(t.y) * 0.8;
-              current.heartEmoji.setPosition(t.x, hy).setScale(hs).setDepth(t.depth+1).setShadow(0, 0, '#000', 4);
+              current.heartEmoji
+                .setPosition(t.x, hy)
+                .setScale(hs)
+                .setDepth(t.depth)
+                .setShadow(0, 0, '#000', 4);
             }
           },
           onComplete:exit});


### PR DESCRIPTION
## Summary
- keep customer mood emojis on the same depth as their sprite
- update dog heart emoji depth updates accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854bd40e514832fb452b97bf996d7c7