### PR TITLE
Add glow effects and disable sell button

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -182,7 +182,12 @@ export function setupGame(){
       }
       btn.setDepth(info.depth);
       btn.setAlpha(0).setVisible(true);
-      if(btn.input) btn.input.enabled = false;
+      if(btn.zone && btn.zone.input) btn.zone.input.enabled = false;
+      if(btn.glow){
+        if(btn.glowTween && btn.glowTween.remove) btn.glowTween.remove();
+        btn.glowTween=null;
+        btn.glow.setVisible(false);
+      }
     };
 
     if(btnSell.list && btnSell.list[0]){
@@ -228,9 +233,29 @@ export function setupGame(){
     });
 
     timeline.setCallback('onComplete', () => {
-      if(canSell && btnSell.input) btnSell.input.enabled = true;
-      if(btnGive.input) btnGive.input.enabled = true;
-      if(btnRef.input) btnRef.input.enabled = true;
+      if(canSell && btnSell.zone && btnSell.zone.input) btnSell.zone.input.enabled = true;
+      if(btnGive.zone && btnGive.zone.input) btnGive.zone.input.enabled = true;
+      if(btnRef.zone && btnRef.zone.input) btnRef.zone.input.enabled = true;
+      if(btnSell.glow){
+        if(canSell){
+          btnSell.glow.setVisible(true).setAlpha(0.6);
+          if(btnSell.glowTween && btnSell.glowTween.remove) btnSell.glowTween.remove();
+          btnSell.glowTween = this.tweens.add({
+            targets: btnSell.glow,
+            alpha: {from:0.6, to:0.2},
+            duration: dur(800),
+            yoyo: true,
+            repeat: -1
+          });
+        }else{
+          if(btnSell.glowTween && btnSell.glowTween.remove) btnSell.glowTween.remove();
+          btnSell.glowTween=null;
+          btnSell.glow.setVisible(false);
+        }
+      }
+      if(btnGive.glow){
+        btnGive.glow.setVisible(true);
+      }
     });
     timeline.play();
   }
@@ -601,19 +626,31 @@ export function setupGame(){
 
 
     // helper to create a button using an image asset
-    const createButton=(x,key,handler,scale=1,depth=12)=>{
+    const createButton=(x,key,handler,scale=1,depth=12,glowColor=null)=>{
       const img=this.add.image(0,0,key).setScale(scale);
       const width=img.displayWidth;
       const height=img.displayHeight;
-      const c=this.add.container(x,BUTTON_Y,[img])
+      const c=this.add.container(x,BUTTON_Y)
         .setSize(width,height)
         .setDepth(depth)
         .setVisible(false);
+
+      if(glowColor){
+        const glow=this.add.graphics();
+        const radius=Math.max(width,height)/2 + 4;
+        glow.fillStyle(glowColor,0.5);
+        glow.fillCircle(0,0,radius);
+        c.add(glow);
+        c.glow=glow;
+      }
+
+      c.add(img);
 
       const zone=this.add.zone(0,0,width,height).setOrigin(0.5);
       zone.setInteractive({ useHandCursor:true });
       zone.on('pointerdown',()=>blinkButton.call(this,c,handler,zone));
       c.add(zone);
+      c.zone=zone;
       return c;
     };
 
@@ -621,8 +658,8 @@ export function setupGame(){
 
     // Arrange buttons: Refuse on the left, Sell in the middle (largest), Give on the right
     btnRef=createButton(110,'refuse',()=>handleAction.call(this,'refuse'),1.15,12);
-    btnSell=createButton(240,'sell',()=>handleAction.call(this,'sell'),1.3,13);
-    btnGive=createButton(370,'give',()=>handleAction.call(this,'give'),1.15,12);
+    btnSell=createButton(240,'sell',()=>handleAction.call(this,'sell'),1.3,13,0xffd700);
+    btnGive=createButton(370,'give',()=>handleAction.call(this,'give'),1.15,12,0xff69b4);
 
 
     // sliding report texts
@@ -954,14 +991,14 @@ export function setupGame(){
               } else {
                 if (canSell) {
                   btnSell.setVisible(true);
-                  if (btnSell.input) btnSell.input.enabled = true;
+                  if (btnSell.zone && btnSell.zone.input) btnSell.zone.input.enabled = true;
                 } else {
                   btnSell.setVisible(false);
-                  if (btnSell.input) btnSell.input.enabled = false;
+                  if (btnSell.zone && btnSell.zone.input) btnSell.zone.input.enabled = false;
                 }
                 btnGive.setVisible(true);
-                if (btnGive.input) btnGive.input.enabled = true;
-                if (btnRef.input) btnRef.input.enabled = true;
+                if (btnGive.zone && btnGive.zone.input) btnGive.zone.input.enabled = true;
+                if (btnRef.zone && btnRef.zone.input) btnRef.zone.input.enabled = true;
               }
             }
           });
@@ -1011,11 +1048,19 @@ export function setupGame(){
       resetPriceBox.call(this);
     }
     btnSell.setVisible(false);
-    if (btnSell.input) btnSell.input.enabled = false;
+    if (btnSell.zone && btnSell.zone.input) btnSell.zone.input.enabled = false;
+    if(btnSell.glow){
+      if(btnSell.glowTween && btnSell.glowTween.remove) btnSell.glowTween.remove();
+      btnSell.glowTween=null;
+      btnSell.glow.setVisible(false);
+    }
     btnGive.setVisible(false);
-    if (btnGive.input) btnGive.input.enabled = false;
+    if (btnGive.zone && btnGive.zone.input) btnGive.zone.input.enabled = false;
+    if(btnGive.glow){
+      btnGive.glow.setVisible(false);
+    }
     btnRef.setVisible(false);
-    if (btnRef.input) btnRef.input.enabled = false;
+    if (btnRef.zone && btnRef.zone.input) btnRef.zone.input.enabled = false;
     tipText.setVisible(false);
 
   }


### PR DESCRIPTION
## Summary
- stop button input when grayed out
- add pink glow to the give button
- add pulsing golden glow to the sell button when active

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854c064eea4832f809e4f651ecbf03a