### PR TITLE
Delay reaction until order gone

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1099,6 +1099,11 @@ export function setupGame(){
             if(dialogText.setColor) dialogText.setColor('#000');
             if(dialogCoins.setColor) dialogCoins.setColor('#000');
             clearDialog.call(this, false);
+            if(lD!==0){
+              animateLoveChange.call(this,lD,current.sprite,done);
+            }else{
+              done();
+            }
           }});
         } else {
           // Only animate the dialog bubble away. Leave the price ticket
@@ -1556,6 +1561,9 @@ export function setupGame(){
             moneyText.setText('🪙 '+receipt(GameState.money));
             animateStatChange(moneyText, this, mD);
             done();
+            if(lD!==0){
+              animateLoveChange.call(this,lD,customer,done);
+            }
         }});
         tl.add({targets:ticket,x:destX,y:destY,scale:0,duration:dur(400),
           onStart:()=>{
@@ -1595,6 +1603,9 @@ export function setupGame(){
               moneyText.setText('🪙 ' + receipt(GameState.money));
               animateStatChange(moneyText, this, mD);
               done();
+              if(lD!==0){
+                animateLoveChange.call(this,lD,customer,done);
+              }
             }
           });
         }, [], this);
@@ -1734,6 +1745,9 @@ export function setupGame(){
           moneyText.setText('🪙 '+receipt(GameState.money));
           animateStatChange(moneyText, this, mD);
           done();
+          if(lD!==0){
+            animateLoveChange.call(this,lD,customer,done);
+          }
       }});
       tl.add({targets:reportLine1,x:midX,y:midY,duration:dur(300),onComplete:()=>{
             const word='SOLD';
@@ -1766,9 +1780,7 @@ export function setupGame(){
       tl.play();
     }
 
-    if(lD!==0){
-      animateLoveChange.call(this,lD,customer,done);
-    }
+    // Reaction happens after the order animation completes
     if(pending===0) finish();
   }
 


### PR DESCRIPTION
## Summary
- show love/anger emojis only after the price ticket animation finishes
- trigger reactions after the dialog bubble leaves in all action paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c02694b4832facdb89fabce9bd1a