### PR TITLE
Add additive blend mode for button glow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -697,6 +697,7 @@ export function setupGame(){
         const radius=Math.max(width,height)/2 + 4;
         glow.fillStyle(glowColor,0.5);
         glow.fillCircle(0,0,radius);
+        glow.setBlendMode(Phaser.BlendModes.ADD);
         c.add(glow);
         c.glow=glow;
       }


### PR DESCRIPTION
## Summary
- set additive blend mode on button glow graphics to soften the effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c5e59210832f9dcb95a0d2f2aca1