### PR TITLE
Fix store dialog stuck after giving

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1805,6 +1805,9 @@ export function setupGame(){
               moneyText.setText('🪙 '+receipt(GameState.money));
               animateStatChange(moneyText, this, mD);
               done();
+              if(lD!==0){
+                animateLoveChange.call(this,lD,customer,done);
+              }
           }});
           if (typeof dialogPriceBox !== 'undefined' && dialogPriceBox) {
             flashBorder(dialogPriceBox,this,0xff0000);


### PR DESCRIPTION
## Summary
- ensure a love animation runs when giving drinks to normal customers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c9e83d64832fae964285a175f173