### PR TITLE
Add brief intro animation

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -12,6 +12,33 @@ let phoneContainer=null;
 let startMsgTimers=[];
 let startMsgBubbles=[];
 
+function playOpening(scene){
+  scene = scene || this;
+  const white=scene.add.rectangle(240,320,480,640,0xffffff,1)
+    .setDepth(14);
+  const emoji=scene.add.text(240,320,'☕👧',{
+      font:'96px sans-serif',fill:'#000'})
+    .setOrigin(0.5)
+    .setDepth(15)
+    .setAlpha(0);
+  const title=scene.add.text(240,420,'Lady Falcon Coffee Club 2',{
+      font:'32px sans-serif',fill:'#000',align:'center',wordWrap:{width:460}})
+    .setOrigin(0.5)
+    .setDepth(15)
+    .setAlpha(0);
+  const tl=scene.tweens.createTimeline({callbackScope:scene,onComplete:()=>{
+    white.destroy();
+    emoji.destroy();
+    title.destroy();
+    showStartScreen.call(scene);
+  }});
+  tl.add({targets:emoji,alpha:1,duration:600,ease:'Sine.easeOut',delay:100});
+  tl.add({targets:title,alpha:1,duration:600,ease:'Sine.easeOut'});
+  tl.add({targets:[emoji,title],alpha:0,duration:600,delay:1000});
+  tl.add({targets:white,alpha:0,duration:600});
+  tl.play();
+}
+
 function showStartScreen(scene){
   scene = scene || this;
   if (typeof debugLog === 'function') debugLog('showStartScreen called');
@@ -305,4 +332,4 @@ function playIntro(scene){
   intro.play();
 }
 
-export { showStartScreen, playIntro };
+export { playOpening, showStartScreen, playIntro };

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ import { startWander } from './entities/wanderers.js';
 import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, setDepthFromBottom, createGrayscaleTexture, createGlowTexture } from './ui/helpers.js';
 
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
-import { showStartScreen, playIntro } from './intro.js';
+import { playOpening, showStartScreen, playIntro } from './intro.js';
 
 export let Assets, Scene, Customers, config;
 export let showStartScreenFn, handleActionFn, spawnCustomerFn, scheduleNextSpawnFn, showDialogFn, animateLoveChangeFn, blinkButtonFn;
@@ -813,8 +813,8 @@ export function setupGame(){
       .setVisible(false)
       .setAlpha(1);
 
-    // wait for player to start the shift
-    showStartScreen.call(this);
+    // play opening sequence before showing start screen
+    playOpening.call(this);
     scheduleSparrowSpawn(this);
 
     // ensure customer sprites match vertical scale and keep drink emoji attached


### PR DESCRIPTION
## Summary
- add a short opening animation that fades in a coffee girl emoji and title card
- trigger the new intro when the scene is created

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854ce542690832fb8d9f816fed6ed08