### PR TITLE
Improve dog moods and pup cup effects

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -433,7 +433,8 @@ export function spawnCustomer() {
     const dog = this.add.sprite(startX + offsetX, startY + offsetY, 'dog1', 1)
       .setOrigin(0.5)
       .setTint(dogType.tint || 0xffffff);
-    dog.scaleFactor = dogType.scale || 0.6;
+    dog.baseScaleFactor = dogType.scale || 0.6;
+    dog.scaleFactor = dog.baseScaleFactor;
     dog.dir = 1;
     dog.prevX = dog.x;
     dog.dogType = dogType.type;


### PR DESCRIPTION
## Summary
- set a baseline scale for dogs
- add `nextMood` helper to advance mood states
- boost a dog's mood when their owner is gifted and reduce it when refused
- let dogs power up and grow when given a pup cup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685608f6dc60832f9baac0f2187d15ee