### PR TITLE
Fix queue tween cancellation

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -169,6 +169,13 @@ export function moveQueueForward() {
     const ty = idx === 0 ? ORDER_Y : QUEUE_Y - QUEUE_OFFSET * (idx - 1);
     if (cust.sprite.y !== ty || cust.sprite.x !== tx) {
       const dir = cust.dir || (cust.sprite.x < tx ? 1 : -1);
+      // Cancel any existing movement tween so starting a new one doesn't leave
+      // customers frozen in place if the old tween was stopped externally.
+      if (cust.walkTween) {
+        cust.walkTween.stop();
+        cust.walkTween.remove();
+        cust.walkTween = null;
+      }
       cust.walkTween = curvedApproach(scene, cust.sprite, dir, tx, ty, () => {
         cust.walkTween = null;
         if (idx === 0) {


### PR DESCRIPTION
## Summary
- cancel any running tween before starting new queue movement

## Testing
- `npm test` *(fails: LOVE_FACE_EMOJIS not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68560cb952d4832f89fdfe1ec6494524