### PR TITLE
Add growth animation for dogs

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -29,6 +29,28 @@ export function scaleDog(d) {
   setDepthFromBottom(d, 5);
 }
 
+export function animateDogGrowth(scene, dog) {
+  if (!scene || !dog) return;
+  const factor = dog.scaleFactor || 0.6;
+  const s = scaleForY(dog.y) * factor;
+  const dir = dog.dir || 1;
+  const finalX = s * dir;
+  const finalY = s;
+  scene.tweens.add({
+    targets: dog,
+    scaleX: finalX * 1.2,
+    scaleY: finalY * 1.2,
+    yoyo: true,
+    repeat: 1,
+    duration: dur(120),
+    onUpdate: () => setDepthFromBottom(dog, 5),
+    onComplete: () => {
+      dog.setScale(finalX, finalY);
+      setDepthFromBottom(dog, 5);
+    }
+  });
+}
+
 // Keep the dog positioned near its owner and react to other customers.
 export function updateDog(owner) {
   const dog = owner && owner.dog;

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from
 import { CustomerState } from './constants.js';
 
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows } from './sparrow.js';
-import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark } from './entities/dog.js';
+import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark, animateDogGrowth } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
 
 import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, setDepthFromBottom, createGrayscaleTexture, createGlowTexture } from './ui/helpers.js';
@@ -1380,6 +1380,8 @@ export function setupGame(){
           const max = base * 2;
           dogSprite.scaleFactor = Math.min(dogSprite.scaleFactor * 1.2, max);
           if(typeof scaleDog === 'function') scaleDog(dogSprite);
+          if(typeof animateDogGrowth === 'function')
+            animateDogGrowth(this, dogSprite);
         }
       }
       if(type==='refuse') memory.state = CustomerState.BROKEN;


### PR DESCRIPTION
## Summary
- add `animateDogGrowth` helper to dog entities
- trigger growth animation when dogs get a treat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c511c1ec832fa3e4c83f525c172c