### PR TITLE
Switch to new sparrow sprite

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','sparrow2','sparrow3','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -80,9 +80,7 @@ export function preload(){
   loader.image('give','assets/give.png');
   loader.image('refuse','assets/refuse.png');
   loader.image('sell','assets/sell.png');
-  loader.spritesheet('sparrow','assets/sparrow.png',{frameWidth:16,frameHeight:16});
-  loader.spritesheet('sparrow2','assets/sparrow2.png',{frameWidth:20,frameHeight:20});
-  loader.spritesheet('sparrow3','assets/sparrow3.png',{frameWidth:20,frameHeight:20});
+  loader.spritesheet('sparrow','assets/sparrow3x1.png',{frameWidth:22,frameHeight:28});
   loader.spritesheet('dog1','assets/dog1.png',{frameWidth:100,frameHeight:100});
   for(const k of genzSprites){
     keys.push(k);

--- a/src/main.js
+++ b/src/main.js
@@ -574,50 +574,14 @@ export function setupGame(){
     });
     this.anims.create({
       key:'sparrow_fly',
-      frames:this.anims.generateFrameNumbers('sparrow',{start:0,end:2}),
+      frames:this.anims.generateFrameNumbers('sparrow',{start:1,end:2}),
       frameRate:8,
       repeat:-1
     });
     this.anims.create({
       key:'sparrow_ground',
-      frames:this.anims.generateFrameNumbers('sparrow',{start:3,end:5}),
-      frameRate:4,
-      repeat:-1
-    });
-    this.anims.create({
-      key:'sparrow_peck',
-      frames:this.anims.generateFrameNumbers('sparrow',{start:6,end:8}),
-      frameRate:6,
-      repeat:-1
-    });
-    this.anims.create({
-      key:'sparrow2_fly',
-      frames:this.anims.generateFrameNumbers('sparrow2',{start:0,end:2}),
-      frameRate:8,
-      repeat:-1
-    });
-    this.anims.create({
-      key:'sparrow2_ground',
-      frames:this.anims.generateFrameNumbers('sparrow2',{start:3,end:5}),
-      frameRate:4,
-      repeat:-1
-    });
-    this.anims.create({
-      key:'sparrow2_peck',
-      frames:this.anims.generateFrameNumbers('sparrow2',{start:6,end:8}),
-      frameRate:6,
-      repeat:-1
-    });
-    this.anims.create({
-      key:'sparrow3_fly',
-      frames:this.anims.generateFrameNumbers('sparrow3',{start:0,end:1}),
-      frameRate:8,
-      repeat:-1
-    });
-    this.anims.create({
-      key:'sparrow3_ground',
-      frames:this.anims.generateFrameNumbers('sparrow3',{start:2,end:3}),
-      frameRate:4,
+      frames:this.anims.generateFrameNumbers('sparrow',{start:0,end:0}),
+      frameRate:1,
       repeat:-1
     });
 

--- a/src/sparrow.js
+++ b/src/sparrow.js
@@ -191,7 +191,6 @@ export class Sparrow {
         this.timer = Phaser.Math.FloatBetween(1,2);
       }else{
         this.timer = Phaser.Math.FloatBetween(1,3);
-        if(Math.random() < 0.5) this.sprite.anims.play('sparrow_peck', true);
       }
     }
   }


### PR DESCRIPTION
## Summary
- load the replacement `sparrow3x1` sprite
- simplify sparrow animations to just fly and sit frames
- drop old `sparrow2` and `sparrow3` assets and animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ccee0da0832f93fd5cc3938c30e1