### PR TITLE
Fix wanderer spawn behaviour

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -531,22 +531,9 @@ export function spawnCustomer() {
   startW(this, c, firstTarget, c.loopsRemaining === 0);
 
   GameState.wanderers.push(c);
-  if ((GameState.queue.length === 0 || GameState.girlReady) && GameState.queue.length < queueLimit() + 3) {
-    lureNextWanderer(this);
-  }
   scheduleNextSpawn(this);
-  if (this.time && this.time.delayedCall) {
-    this.time.delayedCall(1000, () => {
-      if (GameState.girlReady && GameState.queue.length < queueLimit() + 3 && GameState.wanderers.includes(c)) {
-        lureNextWanderer(this);
-      } else if (!GameState.girlReady) {
-        this.time.delayedCall(1000, () => {
-          if (GameState.girlReady && GameState.queue.length < queueLimit() + 3 && GameState.wanderers.includes(c)) {
-            lureNextWanderer(this);
-          }
-        }, [], this);
-      }
-    }, [], this);
-  }
+  // Wanderers should decide to approach the cart on their own rather than being
+  // immediately pulled into line. The intro or queue logic will lure them when
+  // they wander close enough.
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -280,8 +280,10 @@ function testSpawnCustomerQueuesWhenEmpty() {
     time: { addEvent() { return { remove() {} }; }, delayedCall() { return { remove() {} }; } }
   };
   spawnCustomer.call(scene);
-  assert.strictEqual(context.queue.length, 1, 'customer not queued when empty');
-  console.log('spawnCustomer enqueues when queue empty test passed');
+  // Newly spawned customers should remain wanderers until they approach the cart.
+  assert.strictEqual(context.queue.length, 0, 'customer queued prematurely');
+  assert.strictEqual(context.wanderers.length, 1, 'wanderer not added');
+  console.log('spawnCustomer leaves wanderer when queue empty test passed');
 }
 
 function testHandleActionSell() {


### PR DESCRIPTION
## Summary
- stop auto-luring new customers directly into the queue
- adjust tests for new wanderer behaviour

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d8c43e60832f8ca5c4befa6a14ba