### PR TITLE
Improve queue movement timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -368,7 +368,6 @@ export function setupGame(){
   let sideCAlpha=0;
   let sideCFadeTween=null;
   let endOverlay=null;
-  let queueCheckTimer = 0;
   // hearts or anger symbols currently animating
 
 
@@ -784,11 +783,6 @@ export function setupGame(){
       enforceCustomerScaling();
       updateDrinkEmojiPosition();
       updateSparrows(this, dt);
-      queueCheckTimer += dt;
-      if (queueCheckTimer >= 500) {
-        queueCheckTimer = 0;
-        if (typeof checkQueueSpacing === 'function') checkQueueSpacing(this);
-      }
     });
 
 


### PR DESCRIPTION
## Summary
- make queue spacing check event-driven
- cleanly retry `lureNextWanderer`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859d81af080832fbc2668472f90bfcc