### PR TITLE
Adjust emoji reaction timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1195,11 +1195,13 @@ export function setupGame(){
         .setOrigin(0.5).setDepth(11);
     }
     const scoreDuration = 400 + Math.abs(loveDelta || 0) * 250;
+    const holdDuration = Math.max(scoreDuration, 1000);
     this.tweens.add({
       targets: emo,
       y: target.y - 30,
       alpha: 0,
-      duration: dur(scoreDuration),
+      duration: dur(200),
+      delay: dur(holdDuration),
       onComplete: () => {
         if(emojiObj){
           emo.attachedTo = null;


### PR DESCRIPTION
## Summary
- extend reaction emoji lifetime to match scoring duration
- always keep the emoji up for at least one second

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859db231e98832fab48132edcfca308