### PR TITLE
Shift intro number graphic right

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -87,7 +87,7 @@ function playOpening(scene){
     openingTitle.x +
     openingTitle.displayWidth / 2 -
     openingNumber.displayWidth / 2 +
-    10;
+    25; // shift 15px further right
   const finalY =
     openingTitle.y +
     openingTitle.displayHeight / 2 -


### PR DESCRIPTION
## Summary
- tweak intro animation so the '2' lands 15px further right

## Testing
- `scripts/setup.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859de12f4f4832fbb2f4cb40e1d7798