### PR TITLE
Fix early arrival freeze

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -357,6 +357,8 @@ function curvedApproach(scene, sprite, dir, targetX, targetY, onComplete, speed 
       const targetDist = Phaser.Math.Distance.Between(sprite.x, sprite.y, targetX, targetY);
       if (d < EARLY_COLLIDE_DIST && targetDist <= ARRIVAL_DIST_THRESHOLD) {
         if (tween) tween.stop();
+        sprite.setPosition(targetX, targetY);
+        sprite.setScale(scaleForY(targetY));
         cust.walkTween = null;
         registerArrival(scene, cust);
         return true;


### PR DESCRIPTION
## Summary
- ensure customers snap to their target position when early arrival triggers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f3580640832f91207118a0547610