### PR TITLE
Adjust game over screen

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2521,25 +2521,28 @@ function dogsBarkAtFalcon(){
     if(endOverlay){ endOverlay.destroy(); }
     endOverlay = this.add.rectangle(240,320,480,640,0x000000).setDepth(19);
 
-    const title = this.add.text(240,160,'GAME OVER',{
+    const titleGame = this.add.text(240,120,'GAME',{
       font:'80px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
     }).setOrigin(0.5).setDepth(20).setAlpha(0);
-    this.tweens.add({targets:title,alpha:1,duration:dur(600)});
+    const titleOver = this.add.text(240,200,'OVER',{
+      font:'80px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
+    }).setOrigin(0.5).setDepth(20).setAlpha(0);
+    this.tweens.add({targets:[titleGame,titleOver],alpha:1,duration:dur(600)});
 
     const img = this.add.image(240,310,'falcon_end')
       .setScale(1.2)
       .setDepth(20)
       .setAlpha(0);
-    this.tweens.add({targets:img,alpha:1,duration:dur(600),delay:dur(600)});
+    this.tweens.add({targets:img,alpha:1,duration:dur(600),delay:dur(1000)});
 
-    const line1 = this.add.text(240,480,'you lost money',
+    const line1 = this.add.text(240,480,"You've lost all the money",
       {font:'28px sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(21)
       .setAlpha(0);
     this.tweens.add({targets:line1,alpha:1,duration:dur(600),delay:dur(1200)});
 
-    const line2 = this.add.text(240,520,'Lady Falcon reclaims the coffee truck',
+    const line2 = this.add.text(240,520,'Lady Falcon reclaims her coffee truck',
       {font:'28px sans-serif',fill:'#fff',align:'center',wordWrap:{width:440}})
       .setOrigin(0.5)
       .setDepth(21)
@@ -2552,7 +2555,8 @@ function dogsBarkAtFalcon(){
     const againZone = this.add.zone(240,580,btn.width,btn.height).setOrigin(0.5);
     againZone.setInteractive({ useHandCursor:true });
     againZone.on('pointerdown',()=>{
-        title.destroy();
+        titleGame.destroy();
+        titleOver.destroy();
         img.destroy();
         line1.destroy();
         line2.destroy();


### PR DESCRIPTION
## Summary
- tweak `showFalconLoss` to display "GAME" and "OVER" on separate lines
- fade portrait after a second delay
- update loss text to "You've lost all the money" and mention Lady Falcon reclaiming *her* truck

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f46a5ef8832fa66d153a5c5fdcd3