### PR TITLE
Add automatic order timeout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1091,12 +1091,32 @@ export function setupGame(){
       }
     });
 
-    tipText.setVisible(false);
-    if (typeof debugLog === 'function') debugLog('showDialog end');
-  }
+      tipText.setVisible(false);
+      if (typeof debugLog === 'function') debugLog('showDialog end');
+      if (this.time && this.time.delayedCall) {
+        if (GameState.orderTimeoutEvent) {
+          GameState.orderTimeoutEvent.remove(false);
+          GameState.orderTimeoutEvent = null;
+        }
+        GameState.orderTimeoutEvent = this.time.delayedCall(
+          dur(8000),
+          () => {
+            if (GameState.dialogActive && !GameState.saleInProgress) {
+              handleAction.call(this, 'refuse');
+            }
+          },
+          [],
+          this
+        );
+      }
+    }
 
-  function clearDialog(keepPrice=false, resetTicket=true){
+    function clearDialog(keepPrice=false, resetTicket=true){
     GameState.dialogActive = false;
+    if (GameState.orderTimeoutEvent) {
+      GameState.orderTimeoutEvent.remove(false);
+      GameState.orderTimeoutEvent = null;
+    }
     if(!keepPrice){
       dialogBg.setVisible(false);
       dialogText.setVisible(false);
@@ -1223,6 +1243,10 @@ export function setupGame(){
     const current=GameState.activeCustomer;
     if (current) {
       GameState.saleInProgress = true;
+    }
+    if (GameState.orderTimeoutEvent) {
+      GameState.orderTimeoutEvent.remove(false);
+      GameState.orderTimeoutEvent = null;
     }
     if(!current){
       clearDialog.call(this, type!=='refuse');

--- a/src/state.js
+++ b/src/state.js
@@ -9,6 +9,8 @@ export const GameState = {
   lureRetry: null,
   sparrowSpawnEvent: null,
   dogBarkEvent: null,
+  // Clears the dialog if the player doesn't respond in time
+  orderTimeoutEvent: null,
   falconActive: false,
   gameOver: false,
   loveLevel: 1,


### PR DESCRIPTION
## Summary
- avoid customers getting stuck by timing out inactive orders
- cancel timeout when handling or clearing dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f25732dc832f81e76e24dbf5b7ed