### PR TITLE
Adjust game over screen layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2521,15 +2521,15 @@ function dogsBarkAtFalcon(){
     if(endOverlay){ endOverlay.destroy(); }
     endOverlay = this.add.rectangle(240,320,480,640,0x000000).setDepth(19);
 
-    const titleGame = this.add.text(240,120,'GAME',{
+    const titleGame = this.add.text(240,200,'GAME',{
       font:'80px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
     }).setOrigin(0.5).setDepth(20).setAlpha(0);
-    const titleOver = this.add.text(240,200,'OVER',{
+    const titleOver = this.add.text(240,280,'OVER',{
       font:'80px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
     }).setOrigin(0.5).setDepth(20).setAlpha(0);
     this.tweens.add({targets:[titleGame,titleOver],alpha:1,duration:dur(600)});
 
-    const img = this.add.image(240,310,'falcon_end')
+    const img = this.add.image(240,280,'falcon_end')
       .setScale(1.2)
       .setDepth(20)
       .setAlpha(0);
@@ -2540,14 +2540,14 @@ function dogsBarkAtFalcon(){
       .setOrigin(0.5)
       .setDepth(21)
       .setAlpha(0);
-    this.tweens.add({targets:line1,alpha:1,duration:dur(600),delay:dur(1200)});
+    this.tweens.add({targets:line1,alpha:1,duration:dur(1200),delay:dur(1200)});
 
     const line2 = this.add.text(240,520,'Lady Falcon reclaims her coffee truck',
       {font:'28px sans-serif',fill:'#fff',align:'center',wordWrap:{width:440}})
       .setOrigin(0.5)
       .setDepth(21)
       .setAlpha(0);
-    this.tweens.add({targets:line2,alpha:1,duration:dur(600),delay:dur(1800)});
+    this.tweens.add({targets:line2,alpha:1,duration:dur(600),delay:dur(2400)});
 
     const btn = this.add.text(240,580,'Try Again',{font:'20px sans-serif',fill:'#000',backgroundColor:'#ffffff',padding:{x:14,y:8}})
       .setOrigin(0.5)


### PR DESCRIPTION
## Summary
- move GAME/OVER text lower and reposition portrait
- slow fade text on "You've lost all the money"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f874d0a8832f8c407b18e126e3d8