### PR TITLE
Improve customer rejection feedback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1102,7 +1102,11 @@ export function setupGame(){
           dur(8000),
           () => {
             if (GameState.dialogActive && !GameState.saleInProgress) {
-              handleAction.call(this, 'refuse');
+              if (typeof blinkButton === 'function') {
+                blinkButton.call(this, btnRef, () => handleAction.call(this, 'refuse'), btnRef.zone);
+              } else {
+                handleAction.call(this, 'refuse');
+              }
             }
           },
           [],
@@ -1345,6 +1349,10 @@ export function setupGame(){
       current.heartEmoji.destroy();
     }
     current.heartEmoji=null;
+
+    if(type==='refuse'){
+      animateLoveChange.call(this, lD, current);
+    }
 
     if(type==='refuse' && current.dog && current.dog.dogCustomer &&
        current.dog.dogCustomer.memory.state === CustomerState.BROKEN){
@@ -2100,7 +2108,7 @@ export function setupGame(){
         }});
       tl.play();
     };
-    this.time.delayedCall(dur(400),()=>popOne(0),[],this);
+    this.time.delayedCall(dur(1000),()=>popOne(0),[],this);
   }
 
   function showFalconAttack(cb){


### PR DESCRIPTION
## Summary
- highlight the refuse button when auto-refusing
- show broken hearts when a customer is refused
- delay heart pop animation for clearer reactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae8f21bb8832fbda66f4673522c6d