### PR TITLE
Fix handleAction crash when sprite destroyed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1354,11 +1354,16 @@ export function setupGame(){
         current.dog.dogCustomer.memory.state = CustomerState.BROKEN;
       }
     }
+    if (!current.sprite || !current.sprite.scene) {
+      clearDialog.call(this, type!=='refuse');
+      return;
+    }
     if(!current.heartEmoji || !current.heartEmoji.scene || !current.heartEmoji.active){
       if(current.heartEmoji && current.heartEmoji.destroy){
         current.heartEmoji.destroy();
       }
-      current.heartEmoji = current.sprite.scene.add.text(current.sprite.x, current.sprite.y, '', { font: '28px sans-serif' })
+      const scene = current.sprite.scene || this;
+      current.heartEmoji = scene.add.text(current.sprite.x, current.sprite.y, '', { font: '28px sans-serif' })
         .setOrigin(0.5)
         .setShadow(0,0,'#000',4);
     }


### PR DESCRIPTION
## Summary
- avoid using `current.sprite.scene` when the sprite no longer exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b19029b98832fa4fa54ad3a1fc44f