### PR TITLE
Fix queue order position and dog wait timer

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -187,17 +187,21 @@ export function moveQueueForward() {
   }
   const scene = this;
   let willShow = false;
-  const busy = GameState.orderInProgress || GameState.saleInProgress || GameState.dialogActive;
+  const busy = GameState.orderInProgress || GameState.saleInProgress;
   GameState.queue.forEach((cust, idx) => {
     let tx;
     let ty;
-    if (idx === 0 && !busy) {
-      // Counter is free, send the first customer up and mark the order started
-      GameState.orderInProgress = true;
-      tx = ORDER_X;
-      ty = ORDER_Y;
+    if (idx === 0) {
+      if (cust.atOrder || !busy) {
+        if (!cust.atOrder) GameState.orderInProgress = true;
+        tx = ORDER_X;
+        ty = ORDER_Y;
+      } else {
+        tx = QUEUE_X;
+        ty = QUEUE_Y;
+      }
     } else {
-      const spot = idx - (busy ? 0 : 1);
+      const spot = idx - (GameState.orderInProgress ? 1 : 0);
       tx = QUEUE_X - QUEUE_SPACING * Math.max(spot, 0);
       ty = QUEUE_Y - QUEUE_OFFSET * Math.max(spot, 0);
     }
@@ -247,15 +251,20 @@ export function checkQueueSpacing(scene) {
     }
     return;
   }
-  const busy = GameState.orderInProgress || GameState.saleInProgress || GameState.dialogActive;
+  const busy = GameState.orderInProgress || GameState.saleInProgress;
   GameState.queue.forEach((cust, idx) => {
     let tx;
     let ty;
-    if (idx === 0 && !busy) {
-      tx = ORDER_X;
-      ty = ORDER_Y;
+    if (idx === 0) {
+      if (cust.atOrder || !busy) {
+        tx = ORDER_X;
+        ty = ORDER_Y;
+      } else {
+        tx = QUEUE_X;
+        ty = QUEUE_Y;
+      }
     } else {
-      const spot = idx - (busy ? 0 : 1);
+      const spot = idx - (GameState.orderInProgress ? 1 : 0);
       tx = QUEUE_X - QUEUE_SPACING * Math.max(spot, 0);
       ty = QUEUE_Y - QUEUE_OFFSET * Math.max(spot, 0);
     }
@@ -313,6 +322,7 @@ export function startDogWaitTimer(scene, owner) {
       if (owner.waitingForDog) {
         owner.waitingForDog = false;
         if (typeof checkQueueSpacing === 'function') checkQueueSpacing(scene);
+        if (owner.exitHandler) owner.exitHandler();
       }
     }
   });

--- a/src/main.js
+++ b/src/main.js
@@ -1085,34 +1085,11 @@ export function setupGame(){
 
       tipText.setVisible(false);
       if (typeof debugLog === 'function') debugLog('showDialog end');
-      if (this.time && this.time.delayedCall) {
-        if (GameState.orderTimeoutEvent) {
-          GameState.orderTimeoutEvent.remove(false);
-          GameState.orderTimeoutEvent = null;
-        }
-        GameState.orderTimeoutEvent = this.time.delayedCall(
-          dur(8000),
-          () => {
-            if (GameState.dialogActive && !GameState.saleInProgress) {
-              if (typeof blinkButton === 'function') {
-                blinkButton.call(this, btnRef, () => handleAction.call(this, 'refuse'), btnRef.zone);
-              } else {
-                handleAction.call(this, 'refuse');
-              }
-            }
-          },
-          [],
-          this
-        );
-      }
+
     }
 
     function clearDialog(keepPrice=false, resetTicket=true){
     GameState.dialogActive = false;
-    if (GameState.orderTimeoutEvent) {
-      GameState.orderTimeoutEvent.remove(false);
-      GameState.orderTimeoutEvent = null;
-    }
     if(!keepPrice){
       dialogBg.setVisible(false);
       dialogText.setVisible(false);
@@ -1256,10 +1233,6 @@ export function setupGame(){
     const current=GameState.activeCustomer;
     if (current) {
       GameState.saleInProgress = true;
-    }
-    if (GameState.orderTimeoutEvent) {
-      GameState.orderTimeoutEvent.remove(false);
-      GameState.orderTimeoutEvent = null;
     }
     if(!current){
       clearDialog.call(this, type!=='refuse');

--- a/src/state.js
+++ b/src/state.js
@@ -9,8 +9,6 @@ export const GameState = {
   lureRetry: null,
   sparrowSpawnEvent: null,
   dogBarkEvent: null,
-  // Clears the dialog if the player doesn't respond in time
-  orderTimeoutEvent: null,
   falconActive: false,
   gameOver: false,
   loveLevel: 1,


### PR DESCRIPTION
## Summary
- keep front customer at the counter while ordering
- remove the auto-refuse timer
- ensure owners leave after waiting for a missing dog

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c29b0a100832fb28c4030a320ba63