### PR TITLE
Fix dog order tracking

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1594,6 +1594,8 @@ export function setupGame(){
         startDogWaitTimer(this, current);
         current.exitHandler = exit;
         GameState.activeCustomer = dogCust;
+        // Keep the order marked in progress until the dog finishes
+        GameState.orderInProgress = true;
         showDialog.call(this);
         return;
       }


### PR DESCRIPTION
## Summary
- keep queue order status active when a dog's order follows its owner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2a05e6c8832f8624be2646b9ed01