### PR TITLE
Fix stuck queue when order state lingers

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -187,6 +187,12 @@ export function moveQueueForward() {
   }
   const scene = this;
   let willShow = false;
+
+  // Safeguard against a stuck order flag if the prior customer vanished
+  if (GameState.orderInProgress && !GameState.saleInProgress && (!GameState.activeCustomer || !GameState.queue.includes(GameState.activeCustomer))) {
+    GameState.orderInProgress = false;
+  }
+
   const busy = GameState.orderInProgress || GameState.saleInProgress;
   GameState.queue.forEach((cust, idx) => {
     let tx;
@@ -250,6 +256,9 @@ export function checkQueueSpacing(scene) {
       debugLog('checkQueueSpacing abort: waitingForDog');
     }
     return;
+  }
+  if (GameState.orderInProgress && !GameState.saleInProgress && (!GameState.activeCustomer || !GameState.queue.includes(GameState.activeCustomer))) {
+    GameState.orderInProgress = false;
   }
   const busy = GameState.orderInProgress || GameState.saleInProgress;
   GameState.queue.forEach((cust, idx) => {


### PR DESCRIPTION
## Summary
- reset `orderInProgress` when the active customer disappears
- guard against stale order state in `checkQueueSpacing`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2d6e08e8832fb55fc7483bb9b2ea