### PR TITLE
Fix queue order-in-progress logic

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -199,7 +199,10 @@ export function moveQueueForward() {
     let ty;
     if (idx === 0) {
       if (cust.atOrder || !busy) {
-        if (!cust.atOrder) GameState.orderInProgress = true;
+        if (!cust.atOrder) {
+          GameState.orderInProgress = true;
+          cust.atOrder = true; // mark as heading to the counter
+        }
         tx = ORDER_X;
         ty = ORDER_Y;
       } else {
@@ -266,6 +269,10 @@ export function checkQueueSpacing(scene) {
     let ty;
     if (idx === 0) {
       if (cust.atOrder || !busy) {
+        if (!cust.atOrder && !busy) {
+          GameState.orderInProgress = true;
+          cust.atOrder = true; // begin approaching counter
+        }
         tx = ORDER_X;
         ty = ORDER_Y;
       } else {


### PR DESCRIPTION
## Summary
- mark customers as heading to the counter when queue advances
- flag order as in progress when the front customer starts moving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c34cf4ebc832fa6a22996bb57380c