### PR TITLE
Fix invisible dog after refusing owner

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1240,10 +1240,7 @@ export function setupGame(){
     }
     if(type==='refuse' && current.dog){
       if(current.dog.followEvent) current.dog.followEvent.remove(false);
-      const dir = current.dog.x < ORDER_X ? -1 : 1;
-      const offX = dir===1 ? 520 : -40;
-      sendDogOffscreen.call(this, current.dog, offX, current.dog.y);
-      current.dog = null;
+      current.dog.followEvent = null;
     }
 
     const orderCount=current.orders.length;


### PR DESCRIPTION
## Summary
- stop sending dogs offscreen when refusing their owner so the dog can still place an order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c35e46ad0832fb11da3bf27b488c9