### PR TITLE
Improve dog power-up logic

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -29,8 +29,8 @@ export function scaleDog(d) {
   setDepthFromBottom(d, 5);
 }
 
-export function animateDogGrowth(scene, dog) {
-  if (!scene || !dog) return;
+export function animateDogGrowth(scene, dog, cb) {
+  if (!scene || !dog) { if(cb) cb(); return; }
   const factor = dog.scaleFactor || 0.6;
   const s = scaleForY(dog.y) * factor;
   const dir = dog.dir || 1;
@@ -59,6 +59,20 @@ export function animateDogGrowth(scene, dog) {
   tl.setCallback('onComplete', () => {
     dog.setScale(baseX, baseY);
     setDepthFromBottom(dog, 5);
+    if(cb) cb();
+  });
+  tl.play();
+}
+
+export function animateDogPowerUp(scene, dog, cb){
+  if(!scene || !dog){ if(cb) cb(); return; }
+  const tl = scene.tweens.createTimeline();
+  for(let i=0;i<4;i++){
+    tl.add({ targets: dog, alpha: 0, duration: dur(60) });
+    tl.add({ targets: dog, alpha: 1, duration: dur(60) });
+  }
+  tl.setCallback('onComplete', () => {
+    animateDogGrowth(scene, dog, cb);
   });
   tl.play();
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from
 import { CustomerState } from './constants.js';
 
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows } from './sparrow.js';
-import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark, animateDogGrowth } from './entities/dog.js';
+import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark, animateDogPowerUp } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
 
 import { flashBorder, flashFill, blinkButton, applyRandomSkew, emphasizePrice, setDepthFromBottom, createGrayscaleTexture, createGlowTexture } from './ui/helpers.js';
@@ -1163,12 +1163,15 @@ export function setupGame(){
       ease: 'Cubic.easeIn',
       onComplete: () => {
         dialogDrinkEmoji.attachedTo = target;
-        if (this.time) {
-          this.time.delayedCall(dur(100), () => {
-            showDrinkReaction.call(this, target, type, dialogDrinkEmoji, loveDelta, cb);
-          }, [], this);
-        } else {
+        const react = () => {
           showDrinkReaction.call(this, target, type, dialogDrinkEmoji, loveDelta, cb);
+        };
+        if(target.isDog && type==='give'){
+          animateDogPowerUp(this, target, react);
+        } else if (this.time) {
+          this.time.delayedCall(dur(100), react, [], this);
+        } else {
+          react();
         }
       }
     });
@@ -1297,40 +1300,12 @@ export function setupGame(){
           const max = base * 2;
           dogSprite.scaleFactor = Math.min(dogSprite.scaleFactor * 1.2, max);
           if(typeof scaleDog === 'function') scaleDog(dogSprite);
-          if(typeof animateDogGrowth === 'function')
-            animateDogGrowth(this, dogSprite);
         }
       }
       if(type==='refuse') memory.state = CustomerState.BROKEN;
-    } else if(current.dog && current.dog.dogCustomer && current.dog.dogCustomer.memory){
-      const dogMem = current.dog.dogCustomer.memory;
-      if(type==='give') dogMem.state = nextMood(dogMem.state);
-      if(type==='refuse') dogMem.state = CustomerState.BROKEN;
-      const dogSprite = current.dog;
-      if(dogSprite){
-        if(!dogSprite.heartEmoji || !dogSprite.heartEmoji.scene || !dogSprite.heartEmoji.active){
-          if(dogSprite.heartEmoji && dogSprite.heartEmoji.destroy){
-            dogSprite.heartEmoji.destroy();
-          }
-          dogSprite.heartEmoji = dogSprite.scene.add.text(dogSprite.x, dogSprite.y, '', { font: '28px sans-serif' })
-            .setOrigin(0.5)
-            .setShadow(0, 0, '#000', 4);
-        }
-        const hy = dogSprite.y + dogSprite.displayHeight * 0.30;
-        const hs = scaleForY(dogSprite.y) * 0.8;
-        dogSprite.heartEmoji
-          .setText(HEART_EMOJIS[dogMem.state] || '')
-          .setPosition(dogSprite.x, hy)
-          .setScale(hs)
-          .setDepth(dogSprite.depth)
-          .setShadow(0, 0, '#000', 4);
-      }
     }
     if(type==='refuse'){
       memory.state = CustomerState.BROKEN;
-      if(current.dog && current.dog.dogCustomer && current.dog.dogCustomer.memory){
-        current.dog.dogCustomer.memory.state = CustomerState.BROKEN;
-      }
     }
     if (!current.sprite || !current.sprite.scene) {
       clearDialog.call(this, type!=='refuse');


### PR DESCRIPTION
## Summary
- dog mood no longer depends on their owner's order
- add dog power-up animation with blinking and growth
- trigger power-up once pup cup lands before showing reaction

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c353a7cb4832f89a099c31de214a6