### PR TITLE
Improve dog power-up animation

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -39,6 +39,18 @@ export function animateDogGrowth(scene, dog, cb) {
   const tl = scene.tweens.createTimeline();
   const growX = baseX * 1.2;
   const growY = baseY * 1.2;
+  // show an up arrow while the dog grows
+  const arrow = scene.add.text(dog.x, dog.y - dog.displayHeight,
+                              '⬆️', {font:'24px sans-serif'})
+    .setOrigin(0.5)
+    .setDepth(dog.depth + 1)
+    .setScale(scaleForY(dog.y))
+    .setShadow(0,0,'#000',4);
+  const updateArrow = () => {
+    arrow.setPosition(dog.x, dog.y - dog.displayHeight)
+         .setScale(scaleForY(dog.y))
+         .setDepth(dog.depth + 1);
+  };
   for (let i = 0; i < 3; i++) {
     tl.add({
       targets: dog,
@@ -46,7 +58,7 @@ export function animateDogGrowth(scene, dog, cb) {
       scaleY: growY,
       duration: dur(120),
       yoyo: true,
-      onUpdate: () => setDepthFromBottom(dog, 5)
+      onUpdate: () => { setDepthFromBottom(dog, 5); updateArrow(); }
     });
   }
   tl.add({
@@ -54,11 +66,12 @@ export function animateDogGrowth(scene, dog, cb) {
     scaleX: growX,
     scaleY: growY,
     duration: dur(120),
-    onUpdate: () => setDepthFromBottom(dog, 5)
+    onUpdate: () => { setDepthFromBottom(dog, 5); updateArrow(); }
   });
   tl.setCallback('onComplete', () => {
     dog.setScale(baseX, baseY);
     setDepthFromBottom(dog, 5);
+    arrow.destroy();
     if(cb) cb();
   });
   tl.play();

--- a/src/main.js
+++ b/src/main.js
@@ -1167,7 +1167,14 @@ export function setupGame(){
           showDrinkReaction.call(this, target, type, dialogDrinkEmoji, loveDelta, cb);
         };
         if(target.isDog && type==='give'){
-          animateDogPowerUp(this, target, react);
+          // shrink the treat into the dog before the power up
+          const tl = this.tweens.createTimeline();
+          tl.add({ targets: dialogDrinkEmoji, scale: 0, duration: dur(150), ease:'Cubic.easeIn' });
+          tl.add({ targets: dialogDrinkEmoji, alpha:0, duration: dur(80) });
+          tl.setCallback('onComplete', () => {
+            animateDogPowerUp(this, target, react);
+          });
+          tl.play();
         } else if (this.time) {
           this.time.delayedCall(dur(100), react, [], this);
         } else {
@@ -1198,6 +1205,8 @@ export function setupGame(){
     if(emo){
       if(emo.setText) emo.setText(face);
       if(emo.setPosition) emo.setPosition(rx, ry);
+      // reset scaling from any previous drink animations
+      emo.setScale(1);
       emo.setVisible(true).setAlpha(1).setScale(24/28);
       if(emo.base && emo.base.setScale) emo.base.setScale(1);
     }else{


### PR DESCRIPTION
## Summary
- update dog growth animation with an up-arrow indicator
- shrink pup cup into the dog before powering up
- reset emoji scale when showing drink reactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c45bd7724832f8e83e77dc2762dce