### PR TITLE
Fix null phoneContainer in intro timeline

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -386,7 +386,10 @@ function showStartScreen(scene){
       if(openingDog){ openingDog.destroy(); openingDog=null; }
       badgeIcons.forEach(i=>i.destroy());
       badgeIcons=[];
-      phoneContainer.destroy(); phoneContainer=null;
+      if (phoneContainer) {
+        phoneContainer.destroy();
+        phoneContainer = null;
+      }
       GameState.phoneContainer = null;
       playIntro.call(scene);
     }});


### PR DESCRIPTION
## Summary
- avoid destroying `phoneContainer` when it's already null

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c497995ac832fbd3bd32fd44c5987