### PR TITLE
Revise customer dialog

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -447,9 +447,17 @@ export function spawnCustomer() {
   }
   if (GameState.gameOver) return;
   const createOrder = () => {
-    const coins = Phaser.Math.Between(0, 20);
     const item = Phaser.Utils.Array.GetRandom(MENU);
     const qty = 1;
+    // 60% of customers can afford their drink. Give them enough coins for
+    // the item plus a small random tip. The remaining 40% have no money at
+    // all which will trigger an excuse when ordering.
+    let coins;
+    if (Math.random() < 0.6) {
+      coins = item.price + Phaser.Math.Between(0, 5);
+    } else {
+      coins = 0;
+    }
     return { coins, req: item.name, price: item.price, qty };
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -914,32 +914,35 @@ export function setupGame(){
       const canSell = !c.isDog && canAfford;
     let coinLine='';
     if(!c.isDog){
-      if (canAfford) {
-        coinLine = `I have $${c.orders[0].coins}`;
-      } else if (c.orders[0].coins === 0) {
-        const options = ['...but I have nothing', "...I'm poor", "I don't have money"];
+      if (!canAfford) {
+        const options = [
+          "I forgot my wallet",
+          "I'll pay you tomorrow",
+          "My card got declined",
+          "Can I Venmo you later?",
+          "I'm good for it, promise"
+        ];
         coinLine = Phaser.Utils.Array.GetRandom(options);
-      } else {
-        coinLine = `...but I only have $${c.orders[0].coins}`;
       }
     }
     dialogCoins
       .setOrigin(0.5)
       .setStyle({fontSize:'24px'})
       .setText(coinLine)
-      .setVisible(!c.isDog);
+      .setVisible(!c.isDog && !!coinLine);
 
-    const maxW=Math.max(dialogText.width, c.isDog?0:dialogCoins.width);
+    const coinW = (!c.isDog && coinLine) ? dialogCoins.width : 0;
+    const maxW = Math.max(dialogText.width, coinW);
     const hMargin = 20;
     const vMargin = 15;
     const lineGap = 10;
     dialogBg.width = Math.max(maxW + hMargin * 2, 160);
-    dialogBg.height = dialogText.height + (c.isDog?0:dialogCoins.height + lineGap) + vMargin * 2;
+    dialogBg.height = dialogText.height + (coinLine ? dialogCoins.height + lineGap : 0) + vMargin * 2;
 
     const bubbleTop=dialogBg.y - dialogBg.height/2;
     const textY=bubbleTop + vMargin + dialogText.height/2;
     dialogText.setPosition(dialogBg.x, textY);
-    if(!c.isDog){
+    if(!c.isDog && coinLine){
       dialogCoins.setPosition(
         dialogBg.x,
         textY + dialogText.height/2 + lineGap + dialogCoins.height/2
@@ -949,7 +952,11 @@ export function setupGame(){
     dialogBg.setScale(0).setVisible(true);
     GameState.dialogActive = true;
     dialogText.setScale(0);
-    dialogCoins.setScale(0);
+    if (coinLine) {
+      dialogCoins.setScale(0);
+    } else {
+      dialogCoins.setScale(1);
+    }
     // use a static bubble color to avoid expensive image analysis
     let bubbleColor = 0xffffff;
     drawDialogBubble(c.sprite.x, c.sprite.y, bubbleColor);


### PR DESCRIPTION
## Summary
- adjust customer order creation so 40% have no money
- show a Gen Z excuse when the customer is broke
- hide the second dialog line when they can afford their drink

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6395ee2c832fb7d8f7ce4938e68a