### PR TITLE
Fix heart animation detach timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1228,6 +1228,7 @@ export function setupGame(){
 
     this.time.delayedCall(dur(delay), () => {
       if(loveDelta){
+        if(emojiObj) emojiObj.attachedTo = null;
         animateLoveChange.call(this, loveDelta, target, () => {
           if(emojiObj){
             emo.attachedTo = null;


### PR DESCRIPTION
## Summary
- detach reaction emoji before starting love animation so hearts fly correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c956a2888832f9ab65a30a42470f5