### PR TITLE
Fix early exit for dog owners

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -869,6 +869,10 @@ export function setupGame(){
     GameState.activeCustomer=GameState.queue[0]||null;
     if(!GameState.activeCustomer) return;
     const c=GameState.activeCustomer;
+    if(c.isDog && c.owner && c.owner.dogWaitEvent){
+      c.owner.dogWaitEvent.remove(false);
+      c.owner.dogWaitEvent=null;
+    }
     if(!c.isDog && c.dog && c.dog.followEvent){
       const dist = Phaser.Math.Distance.Between(c.dog.x, c.dog.y,
                                                 c.sprite.x, c.sprite.y);


### PR DESCRIPTION
## Summary
- ensure the dog wait timer is cancelled once the dog begins ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c9b3186d4832fa3b5599bf8d54e0b