### PR TITLE
Fix order handling when wanderers arrive together

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -201,7 +201,7 @@ export function moveQueueForward() {
   // or the lead customer is no longer moving toward the counter.
   if (GameState.orderInProgress && !GameState.saleInProgress) {
     const lead = GameState.queue[0];
-    if (!lead || !GameState.queue.includes(GameState.activeCustomer)) {
+    if (!lead || GameState.activeCustomer !== lead) {
       GameState.orderInProgress = false;
     } else if (lead.walkTween && !lead.walkTween.isPlaying &&
                (lead.sprite.x !== ORDER_X || lead.sprite.y !== ORDER_Y)) {
@@ -276,8 +276,11 @@ export function checkQueueSpacing(scene) {
     }
     return;
   }
-  if (GameState.orderInProgress && !GameState.saleInProgress && (!GameState.activeCustomer || !GameState.queue.includes(GameState.activeCustomer))) {
-    GameState.orderInProgress = false;
+  if (GameState.orderInProgress && !GameState.saleInProgress) {
+    const lead = GameState.queue[0];
+    if (!lead || GameState.activeCustomer !== lead) {
+      GameState.orderInProgress = false;
+    }
   }
   const busy = GameState.orderInProgress || GameState.saleInProgress;
   GameState.queue.forEach((cust, idx) => {


### PR DESCRIPTION
## Summary
- ensure the `orderInProgress` flag resets if the queued customer that was headed to the counter is no longer at the front
- same check applied to queue spacing updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb1787968832fad10d0e8e56a8b6c