### PR TITLE
Add falcon death badge counts

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -243,11 +243,18 @@ function showStartScreen(scene){
     const grayKey = `${key}_gray`;
     if(!scene.textures.exists(grayKey)) createGrayscaleTexture(scene, key, grayKey);
     const slot = badgeSlots[key] || { x: iconStartX + idx*36, y: offsetY + bh/2 + 20 };
-    const icon = scene.add.image(slot.x, slot.y, grayKey)
-      .setScale(badgeScale)
+    const iconImg = scene.add.image(0, 0, grayKey)
+      .setScale(badgeScale);
+    const container = scene.add.container(slot.x, slot.y, [iconImg])
       .setDepth(16);
-    phoneContainer.add(icon);
-    badgeIcons.push(icon);
+    if(GameState.badgeCounts[key] > 1){
+      const txt = scene.add.text(0, 0, String(GameState.badgeCounts[key]), {
+        font: '16px sans-serif', fill: '#fff'
+      }).setOrigin(0.5);
+      container.add(txt);
+    }
+    phoneContainer.add(container);
+    badgeIcons.push(container);
   });
 
   if(GameState.carryPortrait && GameState.lastEndKey){

--- a/src/main.js
+++ b/src/main.js
@@ -2656,6 +2656,16 @@ function dogsBarkAtFalcon(){
     againZone.setInteractive({ useHandCursor:true });
     againZone.on('pointerdown',()=>{
         againZone.disableInteractive();
+        const key = img ? img.texture.key : null;
+        if(key){
+          GameState.lastEndKey = key;
+          if(!GameState.badges.includes(key)) GameState.badges.push(key);
+          GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
+          const grayKey = `${key}_gray`;
+          createGrayscaleTexture(this,key,grayKey);
+          img.setTexture(grayKey);
+          GameState.carryPortrait = img.setDepth(25);
+        }
         btn.setVisible(false);
         const overlayG = this.add.graphics({x:btn.x,y:btn.y}).setDepth(23);
         overlayG.fillStyle(0xffffff,1);
@@ -2736,6 +2746,7 @@ function dogsBarkAtFalcon(){
         if(key){
           GameState.lastEndKey = key;
           if(!GameState.badges.includes(key)) GameState.badges.push(key);
+          GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
           const grayKey = `${key}_gray`;
           createGrayscaleTexture(this,key,grayKey);
           img.setTexture(grayKey);

--- a/src/state.js
+++ b/src/state.js
@@ -25,6 +25,7 @@ export const GameState = {
   truck: null,
   girl: null
   ,badges: []
+  ,badgeCounts: {}
   ,carryPortrait: null
   ,lastEndKey: null
   ,phoneContainer: null


### PR DESCRIPTION
## Summary
- track game over counts per badge
- show grayscale achievements for Lady Falcon like Customer Revolt
- overlay badge count text when deaths exceed once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cb65f11a4832fa20e6588c33fd073