### PR TITLE
Fix dog offscreen tween

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -305,6 +305,8 @@ export function updateDog(owner) {
 export function sendDogOffscreen(dog, x, y) {
   if (!dog) return;
   if (dog.followEvent) dog.followEvent.remove(false);
+  // ensure any previous tweens don't fight with the exit tween
+  this.tweens.killTweensOf(dog);
   const dist = Phaser.Math.Distance.Between(dog.x, dog.y, x, y);
   if (Math.abs(x - dog.x) > 3) {
     dog.dir = x > dog.x ? 1 : -1;


### PR DESCRIPTION
## Summary
- fix dogs sometimes disappearing by cancelling any old tweens before sending them offscreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb617015c832f85d1db6e9a30fae0