### PR TITLE
Improve dog power-up visuals

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -81,20 +81,52 @@ export function animateDogGrowth(scene, dog, cb) {
 
 export function animateDogPowerUp(scene, dog, cb){
   if(!scene || !dog){ if(cb) cb(); return; }
+  dog.hideHeart = true;
+  if(dog.heartEmoji && dog.heartEmoji.scene){
+    dog.heartEmoji.setVisible(false);
+  }
+
+  const sparkle = scene.add.text(dog.x, dog.y - dog.displayHeight * 0.5,
+                                 '✨', {font:'24px sans-serif'})
+    .setOrigin(0.5)
+    .setDepth(dog.depth + 1)
+    .setScale(scaleForY(dog.y))
+    .setShadow(0,0,'#000',4);
+  scene.tweens.add({
+    targets: sparkle,
+    y: '-=10',
+    alpha: 0,
+    duration: dur(80),
+    yoyo: true,
+    repeat: 5,
+    onUpdate: () => {
+      sparkle.setPosition(dog.x, dog.y - dog.displayHeight * 0.5)
+             .setDepth(dog.depth + 1)
+             .setScale(scaleForY(dog.y));
+    },
+    onComplete: () => sparkle.destroy()
+  });
+
   const tl = scene.tweens.createTimeline();
   const originalTint = dog.tintTopLeft || 0xffffff;
   const colors = [0xffff66, 0xff66ff, 0x66ffff, 0xffffff];
-  colors.forEach(color => {
-    tl.add({
-      targets: dog,
-      alpha: 0,
-      duration: dur(60),
-      onStart: () => dog.setTint(color)
+  for(let j=0;j<3;j++){
+    colors.forEach(color => {
+      tl.add({
+        targets: dog,
+        alpha: 0,
+        duration: dur(60),
+        onStart: () => dog.setTint(color)
+      });
+      tl.add({ targets: dog, alpha: 1, duration: dur(60) });
     });
-    tl.add({ targets: dog, alpha: 1, duration: dur(60) });
-  });
+  }
   tl.setCallback('onComplete', () => {
     dog.setTint(originalTint);
+    dog.hideHeart = false;
+    if(dog.heartEmoji && dog.heartEmoji.scene){
+      dog.heartEmoji.setVisible(true);
+    }
     animateDogGrowth(scene, dog, cb);
   });
   tl.play();

--- a/src/main.js
+++ b/src/main.js
@@ -380,6 +380,12 @@ export function setupGame(){
       const updateHeart = c => {
         if(!c.sprite || !c.sprite.scene) return;
         const state = c.memory && c.memory.state || CustomerState.NORMAL;
+        if(c.hideHeart){
+          if(c.heartEmoji && c.heartEmoji.scene){
+            c.heartEmoji.setVisible(false);
+          }
+          return;
+        }
         if(!c.heartEmoji || !c.heartEmoji.scene || !c.heartEmoji.active){
           if (c.heartEmoji && c.heartEmoji.destroy) {
             c.heartEmoji.destroy();
@@ -1323,7 +1329,7 @@ export function setupGame(){
           dogSprite.baseScaleFactor = base;
           const max = base * 2;
           // defer applying the new scale until after the power-up animation
-          dogSprite.pendingScaleFactor = Math.min(dogSprite.scaleFactor * 1.2, max);
+          dogSprite.pendingScaleFactor = Math.min(dogSprite.scaleFactor * 1.5, max);
         }
       }
       if(type==='refuse') memory.state = CustomerState.BROKEN;


### PR DESCRIPTION
## Summary
- hide dog mood display during power‑up
- show sparkles and cycle colors when a dog gets a pup cup
- grow dogs by 50% with each pup cup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cbcb8c8ac832fa855d4fc8b9e39c1