### PR TITLE
Fix dog switching leaving queue stuck

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -97,7 +97,7 @@ export function lureNextWanderer(scene, specific) {
   // their dog. This prevents the queue from rechecking and pulling the dog
   // into line accidentally.
   if (GameState.queue.some(q => q.waitingForDog ||
-      (q.isDog && q.owner && q.owner.waitingForDog))) {
+      (q.isDog && q.owner && (q.owner.waitingForDog || q.owner.exitHandler)))) {
     if (typeof debugLog === 'function') {
       debugLog('lureNextWanderer abort: dog switching');
     }
@@ -270,7 +270,7 @@ export function checkQueueSpacing(scene) {
   // to order. This keeps the dog from being pulled into the queue by a
   // recheck triggered by a new arrival.
   if (GameState.queue.some(c => c.waitingForDog ||
-      (c.isDog && c.owner && c.owner.waitingForDog))) {
+      (c.isDog && c.owner && (c.owner.waitingForDog || c.owner.exitHandler)))) {
     if (typeof debugLog === 'function') {
       debugLog('checkQueueSpacing abort: waitingForDog');
     }


### PR DESCRIPTION
## Summary
- prevent new customers from spawning while a dog owner is still exiting
- guard queue spacing checks against owners that haven't finished leaving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7b6728e0832f9d49d920a87d2e6f