### PR TITLE
Add life counters and falcon battle loop

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -24,6 +24,8 @@ export const GameState = {
   girlReady: false,
   truck: null,
   girl: null
+  ,girlHP: 5
+  ,falconHP: 10
   ,badges: []
   ,badgeCounts: {}
   ,carryPortrait: null


### PR DESCRIPTION
## Summary
- give Coffee Girl and Lady Falcon hit points
- display temporary HP numbers above each sprite
- rework `showFalconAttack` so the falcon repeatedly strikes until the girl runs out of HP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7c03ddbc832fbdb92fc8610b5670