### PR TITLE
Fix dog switching queue stall

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -357,7 +357,11 @@ export function startDogWaitTimer(scene, owner) {
       if (owner.waitingForDog) {
         owner.waitingForDog = false;
         if (typeof checkQueueSpacing === 'function') checkQueueSpacing(scene);
-        if (owner.exitHandler) owner.exitHandler();
+        if (owner.exitHandler) {
+          const fn = owner.exitHandler;
+          owner.exitHandler = null;
+          fn();
+        }
       }
     }
   });

--- a/src/main.js
+++ b/src/main.js
@@ -1473,6 +1473,7 @@ export function setupGame(){
       GameState.saleInProgress = false;
       const exit=()=>{
         GameState.orderInProgress = false;
+        current.exitHandler = null;
         if(dialogDrinkEmoji && dialogDrinkEmoji.attachedTo === current.sprite){
           dialogDrinkEmoji.attachedTo = null;
           dialogDrinkEmoji.setVisible(false);


### PR DESCRIPTION
## Summary
- clear dog wait exit handler when the timer fires
- clear exitHandler flag inside exit() so the queue can lure new wanderers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d87770dd8832f9552fc81e3211dc9