### PR TITLE
Add customer respawn cooldown

### DIFF
--- a/src/customers.js
+++ b/src/customers.js
@@ -26,6 +26,8 @@ export const MENU = [
 
 export const SPAWN_DELAY = 2000;
 export const SPAWN_VARIANCE = 1500;
+// Minimum time (ms) before the same customer can appear again
+export const RESPAWN_COOLDOWN = 8000;
 export const QUEUE_SPACING = 36;
 export const ORDER_X = 230;
 export const ORDER_Y = 315;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { debugLog, DEBUG } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_Y, DIALOG_Y } from "./ui.js";
-import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, queueLimit } from "./customers.js";
+import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, calcLoveLevel, queueLimit, RESPAWN_COOLDOWN } from "./customers.js";
 import { lureNextWanderer, moveQueueForward, scheduleNextSpawn, spawnCustomer, startDogWaitTimer, checkQueueSpacing } from './entities/customerQueue.js';
 import { baseConfig } from "./scene.js";
 import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from "./state.js";
@@ -1519,6 +1519,10 @@ export function setupGame(){
         }
         current.heartEmoji = null;
         const winSpriteKey = current.sprite.texture ? current.sprite.texture.key : current.spriteKey;
+        const mem = current.memory;
+        if (mem) {
+          mem.cooldownUntil = (this.time ? this.time.now : Date.now()) + RESPAWN_COOLDOWN;
+        }
         current.sprite.destroy();
         if(GameState.money<=0){
           showFalconAttack.call(this,()=>{


### PR DESCRIPTION
## Summary
- add RESPAWN_COOLDOWN constant to customer settings
- import and apply cooldown when customers exit
- prevent spawning customers again until cooldown expires

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d94ccb33c832f875b7f26f2d02f46