### PR TITLE
Fix falcon attack pacing and remove stray feathers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2509,24 +2509,14 @@ function dogsBarkAtFalcon(){
                    onStart:()=>{girl.setTintFill(0xff0000);sprinkleBursts(scene);},
                    onYoyo:()=>{girl.setTintFill(0xff0000);sprinkleBursts(scene);},
                    onComplete:()=>girl.clearTint()},'<');
-          for(let f=0;f<3;f++){
-            const debris=createDebrisEmoji(scene,falcon.x,falcon.y);
-            tl.add({targets:debris,
-                    x:debris.x+Phaser.Math.Between(-60,60),
-                    y:debris.y+Phaser.Math.Between(-50,10),
-                    angle:Phaser.Math.Between(-360,360),
-                    alpha:0,
-                    duration:dur(400),
-                    onComplete:()=>debris.destroy()},'<');
-            scene.time.delayedCall(dur(450),()=>debris.destroy(),[],scene);
-          }
+          // No more feathers during the attack
           tl.setCallback('onComplete', () => {
             // stopTrail();
             if(firstAttack) firstAttack=false;
             if(GameState.girlHP<=0){
               endAttack();
             } else {
-              scene.time.delayedCall(dur(50),attackOnce,[],scene);
+              attackOnce();
             }
           });
           tl.play();


### PR DESCRIPTION
## Summary
- remove debris feather spawns from the falcon attack
- immediately start backing up for the next attack once an attack finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db396964c832f8dd9c08c3a011774