### PR TITLE
Replace heart counter with HeartHUD

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','heartHUD'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -80,6 +80,7 @@ export function preload(){
   loader.image('give','assets/give.png');
   loader.image('refuse','assets/refuse.png');
   loader.image('sell','assets/sell.png');
+  loader.image('heartHUD','assets/heartHUD.gif');
   loader.spritesheet('sparrow','assets/sparrow3x1.png',{frameWidth:22,frameHeight:28});
   loader.spritesheet('dog1','assets/dog1.png',{frameWidth:100,frameHeight:100});
   for(const k of genzSprites){

--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,7 @@ export function setupGame(){
       callback:()=>{
         obj.setColor(on?color:'#fff');
         if(isLove && !up){
-          obj.setText((on?'💔':'❤️')+' '+GameState.love);
+          obj.setText(String(GameState.love));
         }
         on=!on;
       }
@@ -99,7 +99,7 @@ export function setupGame(){
     scene.time.delayedCall(dur(flashDelay)*(flashes+1)+dur(10),()=>{
       obj.setColor('#fff');
       if(isLove && !up){
-        obj.setText('❤️ '+GameState.love);
+        obj.setText(String(GameState.love));
         // removed wobble animation for the love counter
       }
     },[],scene);
@@ -360,7 +360,7 @@ export function setupGame(){
 
 
 
-  let moneyText, loveText, queueLevelText;
+  let moneyText, loveText, heartHUD, queueLevelText;
   let dialogBg, dialogText, dialogCoins,
       dialogPriceLabel, dialogPriceValue, dialogPriceBox,
       dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket, dialogPupCup,
@@ -517,7 +517,17 @@ export function setupGame(){
 
     // HUD
     moneyText=this.add.text(20,20,'🪙 '+receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
-    loveText=this.add.text(20,50,'❤️ '+GameState.love,{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
+    heartHUD=this.add.image(this.scale.width-20,20,'heartHUD')
+      .setOrigin(1,0)
+      .setScale(0.35)
+      .setDepth(1);
+    loveText=this.add.text(0,0,GameState.love,{font:'26px sans-serif',fill:'#fff'})
+      .setOrigin(0.5)
+      .setDepth(2);
+    loveText.setPosition(
+      heartHUD.x - heartHUD.displayWidth/2,
+      heartHUD.y + heartHUD.displayHeight*0.75
+    );
     moneyText.setInteractive({ useHandCursor:true });
     loveText.setInteractive({ useHandCursor:true });
     moneyText.on('pointerdown',()=>{
@@ -527,7 +537,7 @@ export function setupGame(){
     });
     loveText.on('pointerdown',()=>{
       GameState.love += 10;
-      loveText.setText('❤️ '+GameState.love);
+      loveText.setText(GameState.love);
       updateLevelDisplay();
       animateStatChange(loveText, this, 1, true);
     });
@@ -2102,8 +2112,8 @@ export function setupGame(){
     const sx = startX !== null ? startX : sprite.x;
     const sy = startY !== null ? startY : sprite.y;
 
-    const destX = () => loveText.x + loveText.width + 6;
-    const destY = () => loveText.y + loveText.height;
+    const destX = () => loveText.x;
+    const destY = () => loveText.y;
 
     const showFace = () => isPos ? HAPPY_FACE_EMOJIS[Phaser.Math.Between(0, HAPPY_FACE_EMOJIS.length-1)]
                                 : UPSET_EMOJIS[Phaser.Math.Between(0, UPSET_EMOJIS.length-1)];
@@ -2142,7 +2152,7 @@ export function setupGame(){
           duration:dur(200),
           onComplete:()=>{
             GameState.love += isPos?1:-1;
-            loveText.setText('❤️ '+GameState.love);
+            loveText.setText(String(GameState.love));
             updateLevelDisplay();
             animateStatChange(loveText, this, isPos?1:-1, true);
           }
@@ -2167,8 +2177,8 @@ export function setupGame(){
   function animateBarkPenalty(dog, count, cb){
     const sprite = dog;
     if(!sprite || count<=0){ if(cb) cb(); return; }
-    const destX = () => loveText.x + loveText.width + 6;
-    const destY = () => loveText.y + loveText.height;
+    const destX = () => loveText.x;
+    const destY = () => loveText.y;
     const doOne = (idx) => {
       if(idx >= count){ if(cb) cb(); return; }
       const bark = dogRefuseJumpBark.call(this, sprite, idx===0);
@@ -2200,7 +2210,7 @@ export function setupGame(){
           onComplete: () => {
             bark.destroy();
             GameState.love -= 1;
-            loveText.setText('❤️ ' + GameState.love);
+            loveText.setText(String(GameState.love));
             updateLevelDisplay();
             animateStatChange(loveText, this, -1, true);
             this.time.delayedCall(dur(80), () => doOne(idx+1), [], this);
@@ -3046,7 +3056,7 @@ function dogsBarkAtFalcon(){
     }
     GameState.money=10.00; GameState.love=3;
     moneyText.setText('🪙 '+receipt(GameState.money));
-    loveText.setText('❤️ '+GameState.love);
+    loveText.setText(String(GameState.love));
     updateLevelDisplay();
     if(GameState.activeCustomer){
       if(GameState.activeCustomer.heartEmoji){ GameState.activeCustomer.heartEmoji.destroy(); GameState.activeCustomer.heartEmoji=null; }


### PR DESCRIPTION
## Summary
- load new `heartHUD` asset
- render HeartHUD sprite at top-right of the screen
- overlay love counter on top of HeartHUD
- send reactions to the new HUD position and remove emoji from counter

## Testing
- `npm test` *(fails: http-server stopped after initial tests)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685db75b864c832f81df1148c08647c8