### PR TITLE
Add animated cloud HUD icons

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','heartHUD'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','revolt_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -80,7 +80,8 @@ export function preload(){
   loader.image('give','assets/give.png');
   loader.image('refuse','assets/refuse.png');
   loader.image('sell','assets/sell.png');
-  loader.image('heartHUD','assets/heartHUD.gif');
+  loader.image('cloudHeart','assets/cloudheart.png');
+  loader.image('cloudDollar','assets/clouddollar.png');
   loader.spritesheet('sparrow','assets/sparrow3x1.png',{frameWidth:22,frameHeight:28});
   loader.spritesheet('dog1','assets/dog1.png',{frameWidth:100,frameHeight:100});
   for(const k of genzSprites){

--- a/src/main.js
+++ b/src/main.js
@@ -360,7 +360,7 @@ export function setupGame(){
 
 
 
-  let moneyText, loveText, heartHUD, queueLevelText;
+  let moneyText, loveText, cloudHeart, cloudDollar, queueLevelText;
   let dialogBg, dialogText, dialogCoins,
       dialogPriceLabel, dialogPriceValue, dialogPriceBox,
       dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket, dialogPupCup,
@@ -516,22 +516,31 @@ export function setupGame(){
     bg.setDisplaySize(this.scale.width,this.scale.height);
 
     // HUD
-    moneyText=this.add.text(20,20,'🪙 '+receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'}).setDepth(1);
-    heartHUD=this.add.image(this.scale.width-20,20,'heartHUD')
+    cloudDollar=this.add.image(20,20,'cloudDollar')
+      .setOrigin(0,0)
+      .setDepth(1);
+    moneyText=this.add.text(0,0,receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'})
+      .setOrigin(0.5)
+      .setDepth(2);
+    moneyText.setPosition(
+      cloudDollar.x + cloudDollar.displayWidth/2,
+      cloudDollar.y + cloudDollar.displayHeight/2
+    );
+    cloudHeart=this.add.image(this.scale.width-20,20,'cloudHeart')
       .setOrigin(1,0)
       .setDepth(1);
     loveText=this.add.text(0,0,GameState.love,{font:'26px sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(2);
     loveText.setPosition(
-      heartHUD.x - heartHUD.displayWidth/2,
-      heartHUD.y + heartHUD.displayHeight*0.75
+      cloudHeart.x - cloudHeart.displayWidth/2,
+      cloudHeart.y + cloudHeart.displayHeight/2
     );
     moneyText.setInteractive({ useHandCursor:true });
     loveText.setInteractive({ useHandCursor:true });
     moneyText.on('pointerdown',()=>{
       GameState.money = +(GameState.money + 20).toFixed(2);
-      moneyText.setText('🪙 '+receipt(GameState.money));
+      moneyText.setText(receipt(GameState.money));
       animateStatChange(moneyText, this, 1);
     });
     loveText.on('pointerdown',()=>{
@@ -540,6 +549,11 @@ export function setupGame(){
       updateLevelDisplay();
       animateStatChange(loveText, this, 1, true);
     });
+    // gentle cloud animations
+    this.tweens.add({targets:[cloudHeart,loveText],y:'+=3',duration:1000,yoyo:true,repeat:-1,ease:'Sine.easeInOut'});
+    this.tweens.add({targets:[cloudHeart,loveText],alpha:{from:1,to:0.8},duration:1000,yoyo:true,repeat:-1,ease:'Sine.easeInOut'});
+    this.tweens.add({targets:[cloudDollar,moneyText],y:'+=3',duration:1000,yoyo:true,repeat:-1,ease:'Sine.easeInOut'});
+    this.tweens.add({targets:[cloudDollar,moneyText],alpha:{from:1,to:0.8},duration:1000,yoyo:true,repeat:-1,ease:'Sine.easeInOut'});
     // Indicator for available queue slots
     queueLevelText=this.add.text(156,316,'',{font:'16px sans-serif',fill:'#000'})
       .setOrigin(0.5).setDepth(1).setVisible(false);
@@ -1878,7 +1892,7 @@ export function setupGame(){
             clearDialog.call(this);
             ticket.setVisible(false);
             GameState.money=+(GameState.money+mD).toFixed(2);
-            moneyText.setText('🪙 '+receipt(GameState.money));
+            moneyText.setText(receipt(GameState.money));
             animateStatChange(moneyText, this, mD);
             stopSellGlowSparkle.call(this);
             done();
@@ -1918,7 +1932,7 @@ export function setupGame(){
               clearDialog.call(this);
               ticket.setVisible(false);
               GameState.money = +(GameState.money + mD).toFixed(2);
-              moneyText.setText('🪙 ' + receipt(GameState.money));
+              moneyText.setText(receipt(GameState.money));
               animateStatChange(moneyText, this, mD);
               done();
             }
@@ -2010,7 +2024,7 @@ export function setupGame(){
               clearDialog.call(this);
               ticket.setVisible(false);
               GameState.money=+(GameState.money+mD).toFixed(2);
-              moneyText.setText('🪙 '+receipt(GameState.money));
+              moneyText.setText(receipt(GameState.money));
               animateStatChange(moneyText, this, mD);
               done();
           }});
@@ -2063,7 +2077,7 @@ export function setupGame(){
           reportLine2.setVisible(false).alpha=1;
           reportLine3.setVisible(false).alpha=1;
           GameState.money=+(GameState.money+mD).toFixed(2);
-          moneyText.setText('🪙 '+receipt(GameState.money));
+          moneyText.setText(receipt(GameState.money));
           animateStatChange(moneyText, this, mD);
           done();
           
@@ -3159,7 +3173,7 @@ function dogsBarkAtFalcon(){
       girl.setPosition(startX, 245).setVisible(false);
     }
     GameState.money=10.00; GameState.love=3;
-    moneyText.setText('🪙 '+receipt(GameState.money));
+    moneyText.setText(receipt(GameState.money));
     loveText.setText(String(GameState.love));
     updateLevelDisplay();
     if(GameState.activeCustomer){


### PR DESCRIPTION
## Summary
- load new CloudHeart and CloudDollar assets
- replace old HUD counters with cloud sprites and center text on them
- animate the cloud icons with slow floating and fading

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685df178a514832fb5bf5704185ee6f0