### PR TITLE
Fix restart buttons on loss screens

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2965,16 +2965,25 @@ function dogsBarkAtFalcon(){
       .setAlpha(0);
     this.tweens.add({targets:line2,alpha:1,duration:dur(600),delay:dur(2400)});
 
-    const btn = this.add.text(240,550,'Try Again',{font:'20px sans-serif',fill:'#000',backgroundColor:'#ffffff',padding:{x:14,y:8}})
-      .setOrigin(0.5)
+    const btnText = this.add.text(0,0,'Try Again',{
+      font:'20px sans-serif',
+      fill:'#000',
+      backgroundColor:'#ffffff',
+      padding:{x:14,y:8}
+    }).setOrigin(0.5);
+
+    const btn = this.add.container(240,550,[btnText])
+      .setSize(btnText.width, btnText.height)
       .setDepth(22)
-      .setAlpha(0)
-      .setInteractive({ useHandCursor:true });
+      .setAlpha(0);
+    const btnZone = this.add.zone(0,0,btnText.width,btnText.height).setOrigin(0.5);
+    btnZone.setInteractive({ useHandCursor:true });
+    btn.add(btnZone);
 
     const showBtnDelay = dur(2400) + dur(600) + 1000;
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
-    btn.on('pointerdown',()=>{
-        btn.disableInteractive();
+    btnZone.on('pointerdown',()=>{
+        btnZone.disableInteractive();
         const key = img ? img.texture.key : null;
         if(key){
           GameState.lastEndKey = key;
@@ -3051,17 +3060,26 @@ function dogsBarkAtFalcon(){
       .setAlpha(0);
     this.tweens.add({targets:line2,alpha:1,duration:dur(600),delay:dur(2400)});
 
-    const btn = this.add.text(240,550,'Try Again',{font:'20px sans-serif',fill:'#000',backgroundColor:'#ffffff',padding:{x:14,y:8}})
-      .setOrigin(0.5)
+    const btnText = this.add.text(0,0,'Try Again',{
+      font:'20px sans-serif',
+      fill:'#000',
+      backgroundColor:'#ffffff',
+      padding:{x:14,y:8}
+    }).setOrigin(0.5);
+
+    const btn = this.add.container(240,550,[btnText])
+      .setSize(btnText.width, btnText.height)
       .setDepth(22)
-      .setAlpha(0)
-      .setInteractive({ useHandCursor:true });
+      .setAlpha(0);
+    const btnZone = this.add.zone(0,0,btnText.width,btnText.height).setOrigin(0.5);
+    btnZone.setInteractive({ useHandCursor:true });
+    btn.add(btnZone);
 
     const showBtnDelay = dur(2400) + dur(600) + 1000;
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
 
-    btn.on('pointerdown',()=>{
-        btn.disableInteractive();
+    btnZone.on('pointerdown',()=>{
+        btnZone.disableInteractive();
         const key = img ? img.texture.key : null;
         if(key){
           GameState.lastEndKey = key;


### PR DESCRIPTION
## Summary
- update falcon and revolt loss buttons to use a container plus zone
- attach pointer events to the zone to avoid misaligned hit areas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685df4df93c8832f81f6b1dedf04532e