### PR TITLE
Adjust HUD icons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -529,28 +529,36 @@ export function setupGame(){
     bg.setDisplaySize(this.scale.width,this.scale.height);
 
     // HUD
-    cloudDollar=this.add.sprite(20,20,'cloudDollar')
+    cloudDollar=this.add.sprite(0,20,'cloudDollar')
       .setOrigin(0,0)
       .setDepth(1)
-      .setAlpha(0.4)
+      .setScale(2)
+      .setBlendMode(Phaser.BlendModes.ADD)
+      .setAlpha(0.52)
       .play('cloudDollar_anim');
+    cloudDollar.x = 160 - cloudDollar.displayWidth/2;
     moneyText=this.add.text(0,0,receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(2)
-      .setAlpha(0.4);
+      .setBlendMode(Phaser.BlendModes.ADD)
+      .setAlpha(0.52);
     moneyText.setPosition(
       cloudDollar.x + cloudDollar.displayWidth/2,
       cloudDollar.y + cloudDollar.displayHeight/2
     );
-    cloudHeart=this.add.sprite(this.scale.width-20,20,'cloudHeart')
+    cloudHeart=this.add.sprite(0,20,'cloudHeart')
       .setOrigin(1,0)
       .setDepth(1)
-      .setAlpha(0.4)
+      .setScale(2)
+      .setBlendMode(Phaser.BlendModes.ADD)
+      .setAlpha(0.52)
       .play('cloudHeart_anim');
+    cloudHeart.x = 320 + cloudHeart.displayWidth/2;
     loveText=this.add.text(0,0,GameState.love,{font:'26px sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(2)
-      .setAlpha(0.4);
+      .setBlendMode(Phaser.BlendModes.ADD)
+      .setAlpha(0.52);
     loveText.setPosition(
       cloudHeart.x - cloudHeart.displayWidth/2,
       cloudHeart.y + cloudHeart.displayHeight/2


### PR DESCRIPTION
## Summary
- tweak cloud HUD sprites for money and love counters
- increase size, brightness and shift them inward
- switch HUD text and sprites to additive blend mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dfadcd890832fbd52de34fb407274