### PR TITLE
Update HUD counter appearance

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -533,15 +533,15 @@ export function setupGame(){
       .setOrigin(0,0)
       .setDepth(1)
       .setScale(2)
-      .setBlendMode(Phaser.BlendModes.ADD)
-      .setAlpha(0.52)
+      .setBlendMode(Phaser.BlendModes.LIGHTEN)
+      .setAlpha(0.5)
       .play('cloudDollar_anim');
     cloudDollar.x = 160 - cloudDollar.displayWidth/2;
     moneyText=this.add.text(0,0,receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(2)
-      .setBlendMode(Phaser.BlendModes.ADD)
-      .setAlpha(0.52);
+      .setBlendMode(Phaser.BlendModes.LIGHTEN)
+      .setAlpha(0.5);
     moneyText.setPosition(
       cloudDollar.x + cloudDollar.displayWidth/2,
       cloudDollar.y + cloudDollar.displayHeight/2
@@ -550,15 +550,15 @@ export function setupGame(){
       .setOrigin(1,0)
       .setDepth(1)
       .setScale(2)
-      .setBlendMode(Phaser.BlendModes.ADD)
-      .setAlpha(0.52)
+      .setBlendMode(Phaser.BlendModes.LIGHTEN)
+      .setAlpha(0.5)
       .play('cloudHeart_anim');
     cloudHeart.x = 320 + cloudHeart.displayWidth/2;
     loveText=this.add.text(0,0,GameState.love,{font:'26px sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(2)
-      .setBlendMode(Phaser.BlendModes.ADD)
-      .setAlpha(0.52);
+      .setBlendMode(Phaser.BlendModes.LIGHTEN)
+      .setAlpha(0.5);
     loveText.setPosition(
       cloudHeart.x - cloudHeart.displayWidth/2,
       cloudHeart.y + cloudHeart.displayHeight/2


### PR DESCRIPTION
## Summary
- switch blend mode on money and heart counters to `LIGHTEN`
- tweak their opacity to `0.5`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dfc6e00cc832fa58f541fa22d993d