### PR TITLE
Fix dog exit tween

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -341,7 +341,8 @@ export function sendDogOffscreen(dog, x, y) {
   if (dog.followEvent) dog.followEvent.remove(false);
   // ensure any previous tweens don't fight with the exit tween
   this.tweens.killTweensOf(dog);
-  const dist = Phaser.Math.Distance.Between(dog.x, dog.y, x, y);
+  const targetY = Math.max(DOG_MIN_Y, y);
+  const dist = Phaser.Math.Distance.Between(dog.x, dog.y, x, targetY);
   if (Math.abs(x - dog.x) > 3) {
     dog.dir = x > dog.x ? 1 : -1;
   }
@@ -351,7 +352,7 @@ export function sendDogOffscreen(dog, x, y) {
   this.tweens.add({
     targets: dog,
     x,
-    y,
+    y: targetY,
     duration: dur((dist / DOG_SPEED) * 1000),
     onUpdate: (tw, t) => {
       if (t.prevX === undefined) t.prevX = t.x;

--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -1,6 +1,7 @@
 import { GameState } from '../state.js';
 import { dur, scaleForY } from '../ui.js';
 import { sendDogOffscreen } from './dog.js';
+import { ORDER_X } from '../customers.js';
 
 const EDGE_TURN_BUFFER = 40;
 const EDGE_PAUSE_DURATION = 500; // ms pause before turning around at edges
@@ -20,7 +21,9 @@ export function removeWanderer(scene, c){
   if(idx >= 0) GameState.wanderers.splice(idx,1);
   const ex = c.sprite.x, ey = c.sprite.y;
   if(c.dog){
-    sendDogOffscreen.call(scene,c.dog,ex,ey);
+    const dir = c.sprite.x < ORDER_X ? -1 : 1;
+    const exitX = dir === 1 ? 520 : -40;
+    sendDogOffscreen.call(scene,c.dog,exitX,ey);
     c.dog = null;
   }
   if(c.heartEmoji){ c.heartEmoji.destroy(); c.heartEmoji = null; }


### PR DESCRIPTION
## Summary
- ensure wanderer dogs run fully offscreen before being removed
- keep dogs at or above ground level when exiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dfe86e8e8832fa14fc176c5699f8f