### PR TITLE
Switch HUD clouds to additive blend

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -601,7 +601,8 @@ export function setupGame(){
       .setOrigin(0,0)
       .setDepth(1)
       .setScale(2.4)
-      .setBlendMode(Phaser.BlendModes.SCREEN)
+      // Use additive blend to remove dark areas
+      .setBlendMode(Phaser.BlendModes.ADD)
       .setAlpha(0.9)
       .play('cloudDollar_anim');
     cloudDollar.x = 160 - cloudDollar.displayWidth/2;
@@ -618,7 +619,8 @@ export function setupGame(){
       .setOrigin(1,0)
       .setDepth(1)
       .setScale(2.4)
-      .setBlendMode(Phaser.BlendModes.SCREEN)
+      // Use additive blend to remove dark areas
+      .setBlendMode(Phaser.BlendModes.ADD)
       .setAlpha(0.9)
       .play('cloudHeart_anim');
     cloudHeart.x = 320 + cloudHeart.displayWidth/2;


### PR DESCRIPTION
## Summary
- update `cloudHeart` and `cloudDollar` sprites to use additive blending

## Testing
- `npm test` *(fails: http-server stopped after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_685e035a55b4832f82ee83a698befa2b