### PR TITLE
Fix addPostPipeline error with Canvas renderer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -631,8 +631,11 @@ export function setupGame(){
       return;
     }
 
-    // Register a simple desaturation post-processing pipeline
-    this.renderer.pipelines.addPostPipeline('desaturate', DesaturatePipeline);
+    // Register a simple desaturation post-processing pipeline if WebGL is available
+    if (this.renderer && this.renderer.pipelines &&
+        typeof this.renderer.pipelines.addPostPipeline === 'function') {
+      this.renderer.pipelines.addPostPipeline('desaturate', DesaturatePipeline);
+    }
 
     this.anims.create({
       key:'cloudHeart_anim',
@@ -664,7 +667,8 @@ export function setupGame(){
       .play('cloudDollar_anim')
       .setPostPipeline('desaturate');
 
-    cloudDollar.getPostPipeline('desaturate').amount = 0.5;
+    const dollarPipeline = cloudDollar.getPostPipeline('desaturate');
+    if (dollarPipeline) dollarPipeline.amount = 0.5;
 
     cloudDollar.x = 160 - cloudDollar.displayWidth/2;
     moneyText=this.add.text(0,0,receipt(GameState.money),{font:'26px sans-serif',fill:'#fff'})
@@ -687,7 +691,8 @@ export function setupGame(){
       .play('cloudHeart_anim')
       .setPostPipeline('desaturate');
 
-    cloudHeart.getPostPipeline('desaturate').amount = 0.5;
+    const heartPipeline = cloudHeart.getPostPipeline('desaturate');
+    if (heartPipeline) heartPipeline.amount = 0.5;
 
     cloudHeart.x = 320 + cloudHeart.displayWidth/2;
     loveText=this.add.text(0,0,GameState.love,{font:'26px sans-serif',fill:'#fff'})


### PR DESCRIPTION
## Summary
- ensure post-processing pipelines only register when WebGL is available
- guard `.getPostPipeline` usage on HUD sprites

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685efacf06f8832fb040b30b75b806f9