### PR TITLE
Add red flash on damage

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2419,6 +2419,14 @@ export function setupGame(){
     });
   }
 
+  function flashRed(scene, sprite, duration=250){
+    if(!scene || !sprite) return;
+    sprite.setTintFill(0xff0000);
+    scene.time.delayedCall(dur(duration), ()=>{
+      if(sprite && sprite.clearTint) sprite.clearTint();
+    }, [], scene);
+  }
+
   function showFalconAttack(cb){
     if (GameState.falconActive) return;
     const scene=this;
@@ -2726,9 +2734,8 @@ function dogsBarkAtFalcon(){
             const tl=scene.tweens.createTimeline({callbackScope:scene});
           tl.add({targets:falcon,y:targetY+10,duration:dur(80),yoyo:true});
           tl.add({targets:girl,y:girl.y+5,duration:dur(80),yoyo:true,
-                   onStart:()=>{girl.setTintFill(0xff0000);sprinkleBursts(scene);},
-                   onYoyo:()=>{girl.setTintFill(0xff0000);sprinkleBursts(scene);},
-                   onComplete:()=>girl.clearTint()},'<');
+                   onStart:()=>sprinkleBursts(scene),
+                   onYoyo:()=>sprinkleBursts(scene)},'<');
           // No more feathers during the attack
           tl.setCallback('onComplete', () => {
             // stopTrail();
@@ -2746,19 +2753,11 @@ function dogsBarkAtFalcon(){
     attackOnce();
 
     function blinkAngry(s){
-      s.tweens.add({targets:girl,duration:dur(100),repeat:2,yoyo:true,
-        onStart:()=>girl.setTintFill(0xff0000),
-        onYoyo:()=>girl.setTintFill(0xff0000),
-        onRepeat:()=>girl.clearTint(),
-        onComplete:()=>girl.clearTint()});
+      flashRed(s, girl);
     }
 
     function blinkFalcon(){
-      scene.tweens.add({targets:falcon,duration:dur(100),repeat:2,yoyo:true,
-        onStart:()=>falcon.setTintFill(0xff0000),
-        onYoyo:()=>falcon.setTintFill(0xff0000),
-        onRepeat:()=>falcon.clearTint(),
-        onComplete:()=>falcon.clearTint()});
+      flashRed(scene, falcon);
     }
 
     function sprinkleBursts(s){
@@ -2913,11 +2912,8 @@ function dogsBarkAtFalcon(){
     let finished=false;
 
     function blinkGirl(){
-      scene.tweens.add({targets:girl,duration:dur(60),repeat:2,yoyo:true,x:'+=4',
-        onStart:()=>girl.setTintFill(0xff0000),
-        onYoyo:()=>girl.setTintFill(0xff0000),
-        onRepeat:()=>girl.clearTint(),
-        onComplete:()=>girl.clearTint()});
+      flashRed(scene, girl);
+      scene.tweens.add({targets:girl,duration:dur(60),repeat:2,yoyo:true,x:'+=4'});
     }
 
       function sendDriver(driver){


### PR DESCRIPTION
## Summary
- flash Coffee Girl or Lady Falcon red for a moment when they take damage
- reuse the flash in existing blink helpers
- simplify falcon attack tinting logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685efa795838832fbc12d8861b491021