### PR TITLE
Fix crash in opening fade

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -418,7 +418,10 @@ function showStartScreen(scene){
       playIntro.call(scene);
     }});
     tl.add({targets:phoneContainer,y:-320,duration:600,ease:'Sine.easeIn'});
-    tl.add({targets:[startOverlay,openingTitle,openingNumber,openingDog],alpha:0,duration:600});
+    const fadeTargets = [startOverlay, openingTitle, openingNumber, openingDog].filter(Boolean);
+    if (fadeTargets.length) {
+      tl.add({targets:fadeTargets,alpha:0,duration:600});
+    }
     tl.play();
   });
 


### PR DESCRIPTION
## Summary
- ensure tween targets are defined before fading start overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685efa1a6bd8832face3eed7d1b22428