### PR TITLE
Switch to WebGL renderer for tint effects

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -1,14 +1,11 @@
 const canvas = document.createElement('canvas');
-const context = canvas.getContext('2d', { willReadFrequently: true });
 
 export const baseConfig = {
-  // Explicitly use the Canvas renderer when providing a custom canvas/context.
-  // Phaser throws "Must set explicit renderType in custom environment" if
-  // `Phaser.AUTO` is used with a predefined canvas or context.
-  type: Phaser.CANVAS,
+  // Use WebGL so sprite tinting effects like damage flashes work correctly.
+  // Phaser requires an explicit renderer type when providing a custom canvas.
+  type: Phaser.WEBGL,
   parent: 'game-container',
   canvas,
-  context,
   backgroundColor: '#f2e5d7',
   scale: {
     mode: Phaser.Scale.FIT,


### PR DESCRIPTION
## Summary
- use WebGL renderer rather than Canvas so sprite tinting works

## Testing
- `npm test` *(fails: eslint found errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f14b5065c832fbf44d6ea77392cc9