### PR TITLE
Disable start phone interactions on click

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -395,6 +395,14 @@ function showStartScreen(scene){
     }
   }
   startZone.on('pointerdown',()=>{
+    // Disable further clicks as soon as the intro begins
+    startZone.disableInteractive();
+    if (phoneContainer && phoneContainer.disableInteractive) {
+      phoneContainer.disableInteractive();
+    }
+    if (phoneContainer && phoneContainer.off) {
+      phoneContainer.off('pointerdown');
+    }
     if (typeof debugLog === 'function') debugLog('start button clicked');
     startMsgTimers.forEach(t=>t.remove(false));
     startMsgTimers=[];


### PR DESCRIPTION
## Summary
- prevent repeated taps on start phone by disabling interaction
- remove the phone container's `pointerdown` handler once clicked

## Testing
- `npm test` *(fails: btnZone/btnText not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f15f1f150832f937e16236fa1248a