### PR TITLE
Fix grayscale texture collisions

### DIFF
--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -103,6 +103,7 @@ export function setDepthFromBottom(sprite, base = 5){
 
 export function createGrayscaleTexture(scene, key, destKey){
   if(!scene || !scene.textures || !scene.textures.exists(key)) return;
+  if(scene.textures.exists(destKey)) return scene.textures.get(destKey);
   const srcImg = scene.textures.get(key).getSourceImage();
   if(!srcImg) return;
   const w = srcImg.width;


### PR DESCRIPTION
## Summary
- avoid failing when a grayscale texture already exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f23b919b0832f80ec32d1d92cffac