### PR TITLE
Fix tween cleanup to avoid Phaser errors

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -152,8 +152,10 @@ export function lureNextWanderer(scene, specific) {
 
     const queueIdx = GameState.queue.length;
     if (c.walkTween) {
-      c.walkTween.stop();
-      c.walkTween.remove();
+      if (c.walkTween.isPlaying) {
+        c.walkTween.stop();
+      }
+      if (c.walkTween.remove) c.walkTween.remove();
       c.walkTween = null;
     }
     if (c.pauseEvent) { c.pauseEvent.remove(); c.pauseEvent = null; }
@@ -240,8 +242,8 @@ export function moveQueueForward() {
         if (cust.walkTween.isPlaying) {
           return;
         }
-        cust.walkTween.stop();
-        cust.walkTween.remove();
+        if (cust.walkTween.stop) cust.walkTween.stop();
+        if (cust.walkTween.remove) cust.walkTween.remove();
         cust.walkTween = null;
       }
       cust.walkTween = approachTarget(scene, cust.sprite, dir, tx, ty, () => {
@@ -313,8 +315,8 @@ export function checkQueueSpacing(scene) {
           // never fill beyond two customers.
           return;
         }
-        cust.walkTween.stop();
-        cust.walkTween.remove();
+        if (cust.walkTween.stop) cust.walkTween.stop();
+        if (cust.walkTween.remove) cust.walkTween.remove();
         cust.walkTween = null;
       }
       const dir = cust.dir || (cust.sprite.x < tx ? 1 : -1);

--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -49,7 +49,13 @@ export function handleWanderComplete(scene, c){
 }
 
 export function startWander(scene, c, targetX, exitAfter){
-  if(c.walkTween){ c.walkTween.stop(); c.walkTween.remove(); c.walkTween=null; }
+  if (c.walkTween) {
+    if (c.walkTween.isPlaying) {
+      c.walkTween.stop();
+    }
+    if (c.walkTween.remove) c.walkTween.remove();
+    c.walkTween = null;
+  }
   if(c.pauseEvent){ c.pauseEvent.remove(); c.pauseEvent=null; }
   const startX=c.sprite.x;
   const startY=c.sprite.y;

--- a/src/main.js
+++ b/src/main.js
@@ -1791,7 +1791,7 @@ export function setupGame(){
           current.dog.currentTween = null;
         }
         if(dogCust.walkTween){
-          dogCust.walkTween.stop();
+          if(dogCust.walkTween.isPlaying && dogCust.walkTween.stop) dogCust.walkTween.stop();
           if(dogCust.walkTween.remove) dogCust.walkTween.remove();
           dogCust.walkTween = null;
         }
@@ -2477,7 +2477,10 @@ export function setupGame(){
       fleeing.forEach(c=>{
         const state=c.memory && c.memory.state || CustomerState.NORMAL;
         if(c.heartEmoji){ c.heartEmoji.destroy(); c.heartEmoji=null; }
-        if(c.walkTween){ c.walkTween.stop(); c.walkTween=null; }
+        if(c.walkTween){
+          if(c.walkTween.isPlaying && c.walkTween.stop) c.walkTween.stop();
+          c.walkTween=null;
+        }
         const dir=c.sprite.x<ORDER_X?-1:1;
         const targetX=dir===1?520:-40;
 
@@ -2833,12 +2836,20 @@ function dogsBarkAtFalcon(){
     const gather=(arr)=>{
       arr.forEach(c=>{
         if(!c.memory || c.memory.state !== CustomerState.BROKEN) {
-          if(c.walkTween){ c.walkTween.stop(); if(c.walkTween.remove) c.walkTween.remove(); c.walkTween=null; }
+          if(c.walkTween){
+            if(c.walkTween.isPlaying && c.walkTween.stop) c.walkTween.stop();
+            if(c.walkTween.remove) c.walkTween.remove();
+            c.walkTween=null;
+          }
           if(c.sprite) c.sprite.destroy();
           if(c.dog){ if(c.dog.followEvent) c.dog.followEvent.remove(false); c.dog.destroy(); }
           return;
         }
-        if(c.walkTween){ c.walkTween.stop(); if(c.walkTween.remove) c.walkTween.remove(); c.walkTween=null; }
+        if(c.walkTween){
+          if(c.walkTween.isPlaying && c.walkTween.stop) c.walkTween.stop();
+          if(c.walkTween.remove) c.walkTween.remove();
+          c.walkTween=null;
+        }
         if(c.dog){
           if(c.dog.followEvent) c.dog.followEvent.remove(false);
           c.dog.setDepth(20);
@@ -3387,8 +3398,8 @@ function dogsBarkAtFalcon(){
     }
     GameState.activeCustomer=null;
     cleanupDogs(scene);
-    GameState.queue.forEach(c => { if(c.walkTween){ c.walkTween.stop(); if(c.walkTween.remove) c.walkTween.remove(); c.walkTween=null; } });
-    GameState.wanderers.forEach(c => { if(c.walkTween){ c.walkTween.stop(); if(c.walkTween.remove) c.walkTween.remove(); c.walkTween=null; } });
+    GameState.queue.forEach(c => { if(c.walkTween){ if(c.walkTween.isPlaying && c.walkTween.stop) c.walkTween.stop(); if(c.walkTween.remove) c.walkTween.remove(); c.walkTween=null; } });
+    GameState.wanderers.forEach(c => { if(c.walkTween){ if(c.walkTween.isPlaying && c.walkTween.stop) c.walkTween.stop(); if(c.walkTween.remove) c.walkTween.remove(); c.walkTween=null; } });
     GameState.queue=[];
     GameState.wanderers=[];
     Object.keys(GameState.customerMemory).forEach(k=>{ delete GameState.customerMemory[k]; });


### PR DESCRIPTION
## Summary
- guard against destroying completed tweens
- avoid calling `stop`/`remove` on finished tweens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68604709306c832f8c12503105120fa6