### PR TITLE
Fix tween callback issue

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -75,7 +75,7 @@ export function animateDogGrowth(scene, dog, cb) {
     setDepthFromBottom(dog, 5);
     arrow.destroy();
     if(cb) cb();
-  });
+  }, [], scene);
   tl.play();
 }
 
@@ -105,7 +105,7 @@ export function animateDogPowerUp(scene, dog, cb){
              .setScale(scaleForY(dog.y));
     },
     onComplete: () => sparkle.destroy()
-  });
+  }, [], scene);
 
   const tl = scene.tweens.createTimeline();
   const originalTint = dog.tintTopLeft || 0xffffff;
@@ -130,7 +130,7 @@ export function animateDogPowerUp(scene, dog, cb){
       }
       if(cb) cb();
     });
-  });
+  }, [], scene);
   tl.play();
 }
 
@@ -239,8 +239,8 @@ export function updateDog(owner) {
           .setDepth(dog.depth)
           .setShadow(0, 0, '#000', 4);
         }
-      });
-      tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); });
+      }, [], this);
+      tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); }, [], this);
       dog.currentTween = tl;
       if (dog.anims && dog.play) {
         dog.play('dog_walk');
@@ -333,7 +333,7 @@ export function updateDog(owner) {
       dog.currentTween = null;
       dog.setFrame(1);
     }
-  });
+  }, [], scene);
 }
 
 export function sendDogOffscreen(dog, x, y) {
@@ -442,7 +442,7 @@ export function dogTruckRuckus(scene, dog){
         callback: () => { if(typeof updateDog==='function') updateDog.call(scene, owner); }
       });
     }
-  });
+  }, [], scene);
   if (dog.anims && dog.play) { dog.play('dog_walk'); }
   tl.play();
 }

--- a/src/intro.js
+++ b/src/intro.js
@@ -70,7 +70,7 @@ function playOpening(scene){
         onComplete:()=>cup.destroy()
       });
     }
-  });
+  }, [], scene);
 
   tl.add({
     targets: openingDog,

--- a/src/main.js
+++ b/src/main.js
@@ -341,7 +341,7 @@ export function setupGame(){
           repeat: -1
         });
       }
-    });
+    }, [], this);
     timeline.play();
   }
 
@@ -473,7 +473,7 @@ export function setupGame(){
       });
     }
     if(cb){
-      glowTween.setCallback('onComplete', () => cb());
+      glowTween.setCallback('onComplete', () => cb(), [], this);
     }
   }
 
@@ -1374,7 +1374,7 @@ export function setupGame(){
           tl.add({ targets: dialogDrinkEmoji, alpha:0, duration: dur(80) });
           tl.setCallback('onComplete', () => {
             animateDogPowerUp(this, target, react);
-          });
+          }, [], this);
           tl.play();
         } else if (this.time) {
           this.time.delayedCall(dur(100), react, [], this);
@@ -1753,7 +1753,7 @@ export function setupGame(){
         if(GameState.money<=0){
           showFalconAttack.call(this,()=>{
             showFalconLoss.call(this);
-          });
+          }, [], this);
           return;
         }
         if(GameState.love<=0){
@@ -2525,8 +2525,8 @@ export function setupGame(){
               dog.prevX=dog.x;
               const s=scaleForY(dog.y)*0.5;
               dog.setScale(s*(dog.dir||1), s);
-            });
-            dTl.setCallback('onComplete',()=>{ if(dog) dog.setFrame(1); });
+            }, [], this);
+            dTl.setCallback('onComplete',()=>{ if(dog) dog.setFrame(1); }, [], this);
             if(dog && dog.anims && dog.play){ dog.play('dog_walk'); }
             dTl.play();
           }
@@ -2619,7 +2619,7 @@ function dogsBarkAtFalcon(){
           dog.prevX=dog.x;
           const s=scaleForY(dog.y)*0.5;
           dog.setScale(s*(dog.dir||1), s);
-        });
+        }, [], this);
         dTl.setCallback('onComplete',()=>{
           dog.setFrame(1);
           const dmgPer= (dog.scaleFactor||dog.baseScaleFactor||0.6) > (dog.baseScaleFactor||0.6) ? 1.5 : 1;
@@ -2629,7 +2629,7 @@ function dogsBarkAtFalcon(){
           // burstFeathers(scene, falcon.x, falcon.y, total);
           blinkFalcon();
           if(GameState.falconHP<=0){ endAttack(); }
-        });
+        }, [], this);
         if(dog.anims && dog.play){ dog.play('dog_walk'); }
         dTl.play();
       });


### PR DESCRIPTION
## Summary
- avoid Phaser crash by always providing empty param arrays to `setCallback`
- patch `main.js`, `intro.js`, and `dog.js` to include param arrays when using `setCallback`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860891e3b1c832f9093769989a456aa