### PR TITLE
Improve asset error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by 
 2. If the truck never moves or "Clock In" does nothing, open the browser's developer console (usually F12).
 3. With debug logging enabled (see step 5), look for messages like
    "Asset failed to load" or "init() did not execute."
+   When an asset fails to load, a message now appears on the page reminding
+   you to start the game with `npm start`.
 4. If customers reach the counter but never order, check for
    `showDialog early exit` warnings. This usually means initialization
    failed and some UI elements were never created.

--- a/src/assets.js
+++ b/src/assets.js
@@ -59,10 +59,27 @@ export function emojiFor(name){
   return base;
 }
 
+let loadErrorShown = false;
+
 export function preload(){
   const loader=this.load;
   loader.on('loaderror', file=>{
     if (DEBUG) console.error('Asset failed to load:', file.key || file.src);
+    if (!loadErrorShown && typeof document !== 'undefined') {
+      loadErrorShown = true;
+      const div = document.createElement('div');
+      div.textContent = 'Asset failed to load. Make sure you started the game with `npm start`.';
+      div.style.position = 'fixed';
+      div.style.top = '50%';
+      div.style.left = '50%';
+      div.style.transform = 'translate(-50%, -50%)';
+      div.style.background = 'rgba(0,0,0,0.85)';
+      div.style.color = '#fff';
+      div.style.padding = '1em';
+      div.style.fontFamily = 'sans-serif';
+      div.style.zIndex = 1000;
+      document.body.appendChild(div);
+    }
   });
   loader.image('bg','assets/bg.png');
   loader.image('truck','assets/truck.png');


### PR DESCRIPTION
## Summary
- show an on-page message when asset loading fails
- document the new overlay in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861ece0f2c8832f9f1a744991d6257a