### PR TITLE
Align repo with Node 22.x

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Run tests

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "puppeteer": "^24.10.1"
   },
   "engines": {
-    "node": ">=20 <23"
+    "node": ">=22 <23"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- use Node 22 in GitHub Actions
- require Node 22 via `engines` in `package.json`

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68630cc28aa8832fbc8091218f2dd35d