### PR TITLE
Fix freeze after sale if sell button missing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -436,7 +436,10 @@ export function setupGame(){
   }
 
   function stopSellGlowSparkle(cb){
-    if(!btnSell || !btnSell.glow) return;
+    if(!btnSell || !btnSell.glow){
+      if(cb) cb();
+      return;
+    }
     if(btnSell.sparkleTween && btnSell.sparkleTween.remove){
       btnSell.sparkleTween.remove();
       btnSell.sparkleTween=null;


### PR DESCRIPTION
## Summary
- ensure `stopSellGlowSparkle` calls callback even when the sell button glow is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68631d54565c832fa262289002fc6d15