### PR TITLE
Fix freeze after selling item

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -436,7 +436,10 @@ export function setupGame(){
   }
 
   function stopSellGlowSparkle(cb){
-    if(!btnSell || !btnSell.glow) return;
+    if(!btnSell || !btnSell.glow){
+      if(cb) cb();
+      return;
+    }
     if(btnSell.sparkleTween && btnSell.sparkleTween.remove){
       btnSell.sparkleTween.remove();
       btnSell.sparkleTween=null;


### PR DESCRIPTION
## Summary
- call `stopSellGlowSparkle` callback even when the Sell button glow is missing

## Testing
- `npm test` *(fails to run full test suite due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68631d54565c832fa262289002fc6d15