### PR TITLE
Fix tween callbacks missing params

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -76,7 +76,7 @@ export function animateDogGrowth(scene, dog, cb) {
     setDepthFromBottom(dog, 5);
     arrow.destroy();
     if(cb) cb();
-  });
+  }, []);
   tl.play();
 }
 
@@ -131,7 +131,7 @@ export function animateDogPowerUp(scene, dog, cb){
       }
       if(cb) cb();
     });
-  });
+  }, []);
   tl.play();
 }
 
@@ -240,8 +240,8 @@ export function updateDog(owner) {
           .setDepth(dog.depth)
           .setShadow(0, 0, '#000', 4);
         }
-      });
-      tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); });
+      }, []);
+      tl.setCallback('onComplete', () => { dog.excited = false; dog.currentTween = null; dog.setFrame(1); }, []);
       dog.currentTween = tl;
       if (dog.anims && dog.play) {
         dog.play('dog_walk');
@@ -443,7 +443,7 @@ export function dogTruckRuckus(scene, dog){
         callback: () => { if(typeof updateDog==='function') updateDog.call(scene, owner); }
       });
     }
-  });
+  }, []);
   if (dog.anims && dog.play) { dog.play('dog_walk'); }
   tl.play();
 }

--- a/src/intro.js
+++ b/src/intro.js
@@ -71,7 +71,7 @@ function playOpening(scene){
         onComplete:()=>cup.destroy()
       });
     }
-  });
+  }, []);
 
   tl.add({
     targets: openingDog,

--- a/src/main.js
+++ b/src/main.js
@@ -341,7 +341,7 @@ export function setupGame(){
           repeat: -1
         });
       }
-    });
+    }, []);
     timeline.play();
   }
 
@@ -476,7 +476,7 @@ export function setupGame(){
       });
     }
     if(cb){
-      glowTween.setCallback('onComplete', () => cb());
+      glowTween.setCallback('onComplete', () => cb(), []);
     }
   }
 
@@ -1377,7 +1377,7 @@ export function setupGame(){
           tl.add({ targets: dialogDrinkEmoji, alpha:0, duration: dur(80) });
           tl.setCallback('onComplete', () => {
             animateDogPowerUp(this, target, react);
-          });
+          }, []);
           tl.play();
         } else if (this.time) {
           this.time.delayedCall(dur(100), react, [], this);
@@ -2528,8 +2528,8 @@ export function setupGame(){
               dog.prevX=dog.x;
               const s=scaleForY(dog.y)*0.5;
               dog.setScale(s*(dog.dir||1), s);
-            });
-            dTl.setCallback('onComplete',()=>{ if(dog) dog.setFrame(1); });
+            }, []);
+            dTl.setCallback('onComplete',()=>{ if(dog) dog.setFrame(1); }, []);
             if(dog && dog.anims && dog.play){ dog.play('dog_walk'); }
             dTl.play();
           }
@@ -2622,7 +2622,7 @@ function dogsBarkAtFalcon(){
           dog.prevX=dog.x;
           const s=scaleForY(dog.y)*0.5;
           dog.setScale(s*(dog.dir||1), s);
-        });
+        }, []);
         dTl.setCallback('onComplete',()=>{
           dog.setFrame(1);
           const grown = (dog.scaleFactor||dog.baseScaleFactor||0.6) > (dog.baseScaleFactor||0.6);
@@ -2633,7 +2633,7 @@ function dogsBarkAtFalcon(){
           // burstFeathers(scene, falcon.x, falcon.y, total);
           blinkFalcon();
           if(GameState.falconHP<=0){ endAttack(); }
-        });
+        }, []);
         if(dog.anims && dog.play){ dog.play('dog_walk'); }
         dTl.play();
       });
@@ -2759,7 +2759,7 @@ function dogsBarkAtFalcon(){
             } else {
               attackOnce();
             }
-          });
+          }, []);
           tl.play();
         }});
       }});


### PR DESCRIPTION
## Summary
- prevent Phaser tween callbacks from throwing errors by passing empty param arrays

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686344e83158832f9b06d09ec99b0e91