### PR TITLE
Add note about ?debug=1 logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by 
 
 ## Debugging
 
+Append `?debug=1` to the game URL or set `localStorage.DEBUG = '1'` in the
+browser console to enable verbose logging. For example:
+
+```
+http://localhost:8080/?debug=1
+```
+
 1. Run `npm start` and open the game in a browser.
 2. If the truck never moves or "Clock In" does nothing, open the browser's developer console (usually F12).
 3. With debug logging enabled (see step 5), look for messages like


### PR DESCRIPTION
## Summary
- document how to enable verbose logging via `?debug=1`
- show example URL `http://localhost:8080/?debug=1`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863436d2f94832f914aa0f047a49c41