### PR TITLE
Fix tween callback scope

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -520,14 +520,20 @@ export function spawnCustomer() {
   const startW = typeof startWander === 'function' ? startWander : function(scene, cust, targetX, exitAfter) {
     const duration = (typeof dur === 'function') ? dur(1000) : 1000;
     cust.walkData = { startX: cust.sprite.x, startY: cust.sprite.y, targetX, amp: 0, freq: 0, duration, exitAfter };
-    if (scene && scene.tweens && scene.tweens.add) {
-      scene.tweens.add({ targets: cust.sprite, x: targetX, duration, onComplete: () => {
-        if (exitAfter) {
-          const idx = (GameState.wanderers || scene.wanderers || []).indexOf(cust);
-          if (idx >= 0) (GameState.wanderers || scene.wanderers).splice(idx, 1);
-          if (cust.sprite.destroy) cust.sprite.destroy();
+    if (scene && scene.tweens && scene.tweens.add && cust.sprite) {
+      scene.tweens.add({
+        targets: cust.sprite,
+        x: targetX,
+        duration,
+        callbackScope: scene,
+        onComplete: () => {
+          if (exitAfter) {
+            const idx = (GameState.wanderers || scene.wanderers || []).indexOf(cust);
+            if (idx >= 0) (GameState.wanderers || scene.wanderers).splice(idx, 1);
+            if (cust.sprite.destroy) cust.sprite.destroy();
+          }
         }
-      }});
+      });
     }
   };
 

--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -64,14 +64,20 @@ export function startWander(scene, c, targetX, exitAfter){
   // Slower wander speed now that the line is working
   const walkDuration = Phaser.Math.Between(10000,14000);
   c.walkData={startX,startY,targetX,amp,freq,duration:walkDuration,exitAfter};
-  c.walkTween = scene.tweens.add({targets:c.sprite,x:targetX,duration:dur(walkDuration),
-    onUpdate:(tw,t)=>{
-      const p=tw.progress;
-      t.y=startY+Math.sin(p*Math.PI*freq)*amp;
-      t.setScale(scaleForY(t.y));
-    },
-    onComplete:()=>{ exitAfter ? removeWanderer(scene,c) : handleWanderComplete(scene,c); }
-  });
+  if(scene && scene.tweens && scene.tweens.add && c.sprite){
+    c.walkTween = scene.tweens.add({
+      targets:c.sprite,
+      x:targetX,
+      duration:dur(walkDuration),
+      callbackScope: scene,
+      onUpdate:(tw,t)=>{
+        const p=tw.progress;
+        t.y=startY+Math.sin(p*Math.PI*freq)*amp;
+        t.setScale(scaleForY(t.y));
+      },
+      onComplete:()=>{ exitAfter ? removeWanderer(scene,c) : handleWanderComplete(scene,c); }
+    });
+  }
 }
 
 export function resumeWanderer(scene, c){
@@ -81,15 +87,18 @@ export function resumeWanderer(scene, c){
   const totalDist = Math.abs(targetX - startX);
   const remaining = Math.abs(targetX - c.sprite.x);
   const walkDuration = totalDist>0 ? duration * (remaining/totalDist) : duration;
-  c.walkTween = scene.tweens.add({
-    targets:c.sprite,
-    x:targetX,
-    duration:dur(walkDuration),
-    onUpdate:(tw,t)=>{
-      const p=tw.progress;
-      t.y=startY+Math.sin(p*Math.PI*freq)*amp;
-      t.setScale(scaleForY(t.y));
-    },
-    onComplete:()=>{ exitAfter ? removeWanderer(scene,c) : handleWanderComplete(scene,c); }
-  });
+  if(scene && scene.tweens && scene.tweens.add && c.sprite){
+    c.walkTween = scene.tweens.add({
+      targets:c.sprite,
+      x:targetX,
+      duration:dur(walkDuration),
+      callbackScope: scene,
+      onUpdate:(tw,t)=>{
+        const p=tw.progress;
+        t.y=startY+Math.sin(p*Math.PI*freq)*amp;
+        t.setScale(scaleForY(t.y));
+      },
+      onComplete:()=>{ exitAfter ? removeWanderer(scene,c) : handleWanderComplete(scene,c); }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- ensure fallback wanderer tween runs only when sprite exists
- bind wanderer tween callbacks to scene

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686344fc688c832f94ecfd82e0f180b7