### PR TITLE
Improve dog power-up visuals and add mood test

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -61,7 +61,7 @@ export function animateDogGrowth(scene, dog, cb) {
       scaleY: growY,
       duration: dur(120),
       yoyo: true,
-      onUpdate: () => { setDepthFromBottom(dog, 5); updateArrow(); }
+      onUpdate: () => { setDepthFromBottom(dog, 100); updateArrow(); }
     });
   }
   tl.add({
@@ -69,7 +69,7 @@ export function animateDogGrowth(scene, dog, cb) {
     scaleX: growX,
     scaleY: growY,
     duration: dur(120),
-    onUpdate: () => { setDepthFromBottom(dog, 5); updateArrow(); }
+    onUpdate: () => { setDepthFromBottom(dog, 100); updateArrow(); }
   });
   tl.setCallback('onComplete', () => {
     dog.setScale(baseX, baseY);

--- a/test/test.js
+++ b/test/test.js
@@ -1033,6 +1033,22 @@ function testEmojiFor() {
   console.log('emojiFor test passed');
 }
 
+function testNextMoodProgression() {
+  const src = extractFunction(['main.js'], 'nextMood');
+  if (!src) throw new Error('nextMood not found');
+  const context = {};
+  loadCustomerState(context);
+  vm.createContext(context);
+  vm.runInContext(src + '\nfn=nextMood;', context);
+  const nextMood = context.fn;
+  const CS = context.CustomerState;
+  assert.strictEqual(nextMood(CS.NORMAL), CS.GROWING, 'NORMAL -> GROWING');
+  assert.strictEqual(nextMood(CS.GROWING), CS.SPARKLING, 'GROWING -> SPARKLING');
+  assert.strictEqual(nextMood(CS.SPARKLING), CS.ARROW, 'SPARKLING -> ARROW');
+  assert.strictEqual(nextMood(CS.ARROW), CS.ARROW, 'ARROW stays ARROW');
+  console.log('nextMood progression test passed');
+}
+
 async function testIntroSequence() {
   const puppeteer = require('puppeteer');
   const { PNG } = require('pngjs');
@@ -1177,6 +1193,7 @@ async function run() {
     testSparrowRemovalOffscreen();
     testLureNextWandererQueueLimit();
     testShowEndRestart();
+    testNextMoodProgression();
     testEmojiFor();
     if (!SKIP_PUPPETEER) {
       await testIntroSequence();


### PR DESCRIPTION
## Summary
- keep dog sprite on top during growth animation
- test mood progression when giving PupCups

## Testing
- `DEBUG=1 SKIP_PUPPETEER=1 node test/test.js` *(fails: money not updated correctly)*

------
https://chatgpt.com/codex/tasks/task_e_686355cda8f8832fb6c3e598209cff8d