### PR TITLE
Add debug speed control

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import { debugLog, DEBUG } from './debug.js';
-import { dur, scaleForY, articleFor, flashMoney, BUTTON_Y, DIALOG_Y } from "./ui.js";
+import { dur, scaleForY, articleFor, flashMoney, BUTTON_Y, DIALOG_Y, setSpeedMultiplier } from "./ui.js";
 import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, queueLimit, RESPAWN_COOLDOWN } from "./customers.js";
 import { lureNextWanderer, moveQueueForward, scheduleNextSpawn, spawnCustomer, startDogWaitTimer } from './entities/customerQueue.js';
 import { baseConfig } from "./scene.js";
@@ -611,6 +611,23 @@ export function setupGame(){
     }
   }
 
+  function addSpeedControl(scene){
+    const speeds=[1,2,5,10];
+    let idx=0;
+    const label=scene.add.text(scene.scale.width-10,10,'1x',{
+      font:'16px sans-serif',fill:'#fff',backgroundColor:'#000'
+    })
+      .setOrigin(1,0)
+      .setPadding(4)
+      .setDepth(30)
+      .setInteractive({useHandCursor:true});
+    label.on('pointerdown',()=>{
+      idx=(idx+1)%speeds.length;
+      setSpeedMultiplier(speeds[idx]);
+      label.setText(`${speeds[idx]}x`);
+    });
+  }
+
 
 
 
@@ -622,6 +639,9 @@ export function setupGame(){
     this.assets = Assets;
     this.customers = Customers;
     this.gameState = GameState;
+    this.dur = dur;
+    setSpeedMultiplier(1);
+    if (DEBUG) addSpeedControl(this);
     const missing=requiredAssets.filter(key=>!this.textures.exists(key));
     if(missing.length){
       const msg='Missing assets: '+missing.join(', ');

--- a/src/ui.js
+++ b/src/ui.js
@@ -11,7 +11,16 @@ export const BUTTON_Y = 545;
 export const DIALOG_Y = 400;
 
 // Wraps timing values so any global speed adjustments can be made here
-export const dur = v => v;
+let speedMultiplier = 1;
+export function setSpeedMultiplier(m = 1) {
+  speedMultiplier = m || 1;
+}
+export function getSpeedMultiplier() {
+  return speedMultiplier;
+}
+export function dur(v) {
+  return v / speedMultiplier;
+}
 
 export function scaleForY(y) {
   const minY = ORDER_Y;


### PR DESCRIPTION
## Summary
- allow changing global timing with `setSpeedMultiplier`
- show a debug speed button cycling 1x/2x/5x/10x

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68641c1a5d30832f9faadd4ddeb88e3a