### PR TITLE
Improve end sequence pacing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3131,6 +3131,7 @@ function dogsBarkAtFalcon(){
 
     function falconDies(){
       if(!falcon) return;
+      setSpeedMultiplier(0.25);
       scene.tweens.killAll();
       scene.time.removeAllEvents();
       reinHumanEvents.forEach(ev=>{ if(ev) ev.remove(false); });
@@ -3153,7 +3154,12 @@ function dogsBarkAtFalcon(){
         y:'+=100',
         duration:dur(1500),
         ease:'Cubic.easeIn',
-        onComplete:endAttack
+        onComplete:()=>{
+          scene.time.delayedCall(2000,()=>{
+            setSpeedMultiplier(1);
+            endAttack();
+          });
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- add slow motion effect when Lady Falcon dies
- delay end screen until she lands plus 2s

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864566d1084832fa52d63ef90be7773