### PR TITLE
Stop falcon animation after death

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3180,6 +3180,7 @@ function dogsBarkAtFalcon(){
         duration:dur(1500),
         ease:'Cubic.easeIn',
         onComplete:()=>{
+          if(falcon && falcon.anims) falcon.anims.stop();
           scene.time.delayedCall(2000,()=>{
             setSpeedMultiplier(1);
             endAttack();


### PR DESCRIPTION
## Summary
- make lady falcon stop animating once it hits the ground

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_686469db70c4832fbaddb45ad2211430