### PR TITLE
Handle dog death during falcon attack

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -158,7 +158,7 @@ export function animateDogPowerUp(scene, dog, cb){
 // Keep the dog positioned near its owner and react to other customers.
 export function updateDog(owner) {
   const dog = owner && owner.dog;
-  if (!dog || !owner.sprite) return;
+  if (!dog || !owner.sprite || dog.dead) return;
   const ms = owner.sprite;
   const dogDist = Phaser.Math.Distance.Between(dog.x, dog.y, ms.x, ms.y);
   let radius = DOG_ROAM_RADIUS;


### PR DESCRIPTION
## Summary
- skip updating dogs once dead
- ignore dead dogs in the falcon encounter
- blink and clean up dog after falcon attack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68647aa2a374832fa2dcd1367b1031dd