### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ When you choose to sell or give a drink, the button briefly blinks.
 After the animation finishes, the button automatically becomes
 clickable again so you can quickly serve the next customer.
 
+You can also use the keyboard:
+
+* **A** - Refuse a customer
+* **S** - Sell the order
+* **D** - Give the order for free
+
 The price text used to flash green when a sale completed. That effect
 has been removed so the amount simply updates without flashing.
 

--- a/src/main.js
+++ b/src/main.js
@@ -945,6 +945,14 @@ export function setupGame(){
     btnSell=createButton(240,'sell',()=>handleAction.call(this,'sell'),1.15,13,0xffd700);
     btnGive=createButton(370,'give',()=>handleAction.call(this,'give'),1.0,12,0xff69b4);
 
+    const triggerBtn = btn => {
+      if (!btn || !btn.zone || (btn.zone.input && !btn.zone.input.enabled)) return;
+      if (btn.zone.emit) btn.zone.emit('pointerdown');
+    };
+    this.input.keyboard.on('keydown-A', () => triggerBtn(btnRef));
+    this.input.keyboard.on('keydown-S', () => triggerBtn(btnSell));
+    this.input.keyboard.on('keydown-D', () => triggerBtn(btnGive));
+
 
     // sliding report texts
     reportLine1=this.add.text(480,moneyText.y,'',{font:'16px sans-serif',fill:'#fff'})


### PR DESCRIPTION
## Summary
- add A/S/D keyboard shortcuts for refuse/sell/give actions
- document keyboard controls in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68649210e6cc832f93c46e000901e97a