### PR TITLE
Prevent queue activity during falcon fight

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -90,6 +90,7 @@ function customerQueueThreshold(cust){
 }
 
 export function lureNextWanderer(scene, specific) {
+  if (GameState.falconActive) return;
   if (typeof debugLog === 'function') {
     debugLog('lureNextWanderer', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
   }
@@ -206,6 +207,7 @@ export function lureNextWanderer(scene, specific) {
 }
 
 export function moveQueueForward() {
+  if (GameState.falconActive) return;
   if (typeof debugLog === 'function') {
     debugLog('moveQueueForward', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
   }
@@ -281,6 +283,7 @@ export function moveQueueForward() {
 }
 
 export function checkQueueSpacing(scene) {
+  if (GameState.falconActive) return;
   // Avoid adjusting the line while a customer is waiting for their dog
   // to order. This keeps the dog from being pulled into the queue by a
   // recheck triggered by a new arrival.

--- a/src/main.js
+++ b/src/main.js
@@ -1050,6 +1050,7 @@ export function setupGame(){
   }
 
   function showDialog(){
+    if (GameState.falconActive) return;
     if (GameState.saleInProgress || GameState.dialogActive) {
       // Defer showing the next order until the current sale animation finishes
       // or while another dialog is already visible


### PR DESCRIPTION
## Summary
- skip lure/queue updates while Lady Falcon is active
- avoid showing dialogs during falcon attack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864bc01c530832f9cb9b397bf1f5abc