### PR TITLE
Fix endless attack loop after girl defeat

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3063,6 +3063,7 @@ function dogsBarkAtFalcon(){
     spawnReinforcements();
     scene.events.on('update', updateReinforcementHearts);
     const attackOnce=()=>{
+        if(finished) return;
         const activeHumans = reinHumans.filter(h => h.active).length;
         if(activeHumans === 0 && reinDogs.length > 0){
           falconAttackDog(reinDogs[0], () => scene.time.delayedCall(dur(400), attackOnce, [], scene));


### PR DESCRIPTION
## Summary
- stop pending Falcon attacks when the girl's HP drops to zero

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864bc51e1d8832fa32b7864807465d6