### PR TITLE
Fix falcon victory asset reference

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -90,7 +90,8 @@ export function preload(){
   loader.image('title2','assets/title2.png');
   loader.spritesheet('lady_falcon','assets/lady_falcon.png',{frameWidth:64,frameHeight:64});
   loader.image('falcon_end','assets/ladyfalconend.png');
-  loader.image('falcon_victory','assets/falconvictory.png');
+  // Correct file extension and name for falcon victory asset
+  loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('revolt_end','assets/revolt.png');
   loader.image('price_ticket','assets/priceticket.png');
   loader.image('pupcup','assets/pupcup.png');


### PR DESCRIPTION
## Summary
- update `falcon_victory` asset path to use the correct GIF file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654895bea4832fae51796cd91473ad