### PR TITLE
Fix stuck state after coffee girl defeat

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2718,8 +2718,8 @@ function dogsBarkAtFalcon(){
     let featherTrail=null;
     let firstAttack=true;
     let attackTween=null;
-    const endAttack=()=>{
-      if(finished) return;
+    const endAttack=(force=false)=>{
+      if(finished && !force) return;
       finished=true;
       if(GameState.dogBarkEvent){
         GameState.dogBarkEvent.remove(false);
@@ -3130,7 +3130,7 @@ function dogsBarkAtFalcon(){
               bigCoffeeExplosion(scene);
               scene.time.delayedCall(2000, ()=>{
                 setSpeedMultiplier(1);
-                endAttack();
+                endAttack(true);
               }, [], scene);
             } else {
               attackOnce();


### PR DESCRIPTION
## Summary
- ensure endAttack runs even if attack already marked finished
- mark battle finished when coffee girl HP hits 0 and call endAttack with force

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686552d5b188832fa4609819741b719c