### PR TITLE
Ensure on-screen dogs reset attack on revolt

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3370,6 +3370,11 @@ function dogsBarkAtFalcon(){
         }
         if(c.dog){
           if(c.dog.followEvent) c.dog.followEvent.remove(false);
+          if(c.dog.currentTween){ c.dog.currentTween.stop(); c.dog.currentTween = null; }
+          if(c.dog.chewEvent){ c.dog.chewEvent.remove(false); c.dog.chewEvent = null; }
+          if(c.dog.wiggleTween){ c.dog.wiggleTween.stop(); c.dog.wiggleTween = null; }
+          scene.tweens.killTweensOf(c.dog);
+          c.dog.attacking = false;
           c.dog.setDepth(20);
           attackerDogs.push(c.dog);
           if(!c.dog.heartEmoji){


### PR DESCRIPTION
## Summary
- stop any ongoing dog tweens/events when gathering dogs for the revolt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686570b12d60832f82b8716553108e80