### PR TITLE
Add dog death fall & tint

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3051,10 +3051,24 @@ function dogsBarkAtFalcon(){
             onComplete: () => {
               if(dog.anims && dog.anims.stop) dog.anims.stop();
               else if(dog.anims && dog.anims.pause) dog.anims.pause();
-              dog.dead = true;
-              const idx = reinDogs.indexOf(dog);
-              if(idx !== -1) reinDogs.splice(idx,1);
-              if(done) done();
+              dog.setTint(0x888888);
+              scene.tweens.add({
+                targets: dog,
+                y: DOG_MIN_Y,
+                duration: dur(300),
+                ease: 'Sine.easeIn',
+                onUpdate: () => {
+                  const s = scaleForY(dog.y) * (dog.scaleFactor || 0.5);
+                  dog.setScale(s * (dog.dir || 1), s);
+                },
+                onComplete: () => {
+                  ensureOnGround(dog);
+                  dog.dead = true;
+                  const idx = reinDogs.indexOf(dog);
+                  if(idx !== -1) reinDogs.splice(idx,1);
+                  if(done) done();
+                }
+              });
             }
           });
         }


### PR DESCRIPTION
## Summary
- when a falcon kills a dog, make the dog drop to `DOG_MIN_Y`
- tint dead dogs gray so they're clearly lifeless

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686597357e38832f866a24152d53a664