### PR TITLE
Improve minigame integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
       }
       #version1-frame {
         position: absolute;
-        width: 260px;
-        height: 500px;
+        width: 480px;
+        height: 640px;
         left: 50%;
         top: 50%;
         transform: translate(-50%, -50%);
@@ -32,6 +32,8 @@
     window.showMiniGame = function() {
       const f = document.getElementById('version1-frame');
       if (f) {
+        if (window.hideStartMessages) window.hideStartMessages();
+        window.minigameActive = true;
         f.src = 'version1.html';
         f.style.display = 'block';
       }
@@ -42,6 +44,7 @@
         f.style.display = 'none';
         f.src = '';
       }
+      window.minigameActive = false;
     };
   </script>
 </body>

--- a/src/intro.js
+++ b/src/intro.js
@@ -18,6 +18,13 @@ let openingNumber = null;
 let openingDog = null;
 let badgeIcons = [];
 
+function hideStartMessages(){
+  startMsgTimers.forEach(t=>t.remove(false));
+  startMsgTimers=[];
+  startMsgBubbles.forEach(b=>b.destroy());
+  startMsgBubbles=[];
+}
+
 function playOpening(scene){
   scene = scene || this;
   startWhite = scene.add.rectangle(240,320,480,640,0xffffff,1)
@@ -632,4 +639,8 @@ function playIntro(scene){
   intro.play();
 }
 
-export { playOpening, showStartScreen, playIntro };
+export { playOpening, showStartScreen, playIntro, hideStartMessages };
+
+if (typeof window !== 'undefined') {
+  window.hideStartMessages = hideStartMessages;
+}

--- a/version1.html
+++ b/version1.html
@@ -9,7 +9,7 @@
     html, body, #game-container {
       margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden;
     }
-    body { background: #f2e5d7; }
+    body { background: #5c3b2a; }
     #game-container { position: relative; }
   </style>
 </head>
@@ -33,7 +33,7 @@ window.onload = function() {
   const config = {
     type: Phaser.AUTO,
     parent: 'game-container',
-    backgroundColor: '#f2e5d7',
+    backgroundColor: '#5c3b2a',
     scale: {
       mode: Phaser.Scale.FIT,
       autoCenter: Phaser.Scale.CENTER_BOTH,
@@ -65,7 +65,7 @@ window.onload = function() {
                    .setOrigin(1,0).setDepth(0);
 
     // Truck
-    this.add.image(240,180,'truck').setScale(0.25).setDepth(1);
+    this.add.image(240,180,'truck').setScale(0.5).setDepth(1);
 
     // Dialog UI
     dialogBg = this.add.rectangle(240,520,420,180,0xffffff)
@@ -123,7 +123,7 @@ window.onload = function() {
     currentCoins = Phaser.Math.Between(1,10);
     currentRequest = currentCoins < COFFEE_COST ? 'water':'coffee';
     const key = Phaser.Utils.Array.GetRandom(['genz1','genz2','genz3']);
-    currentCustomer = this.add.sprite(240,640,key).setOrigin(0.5,1).setScale(0.075).setDepth(1);
+    currentCustomer = this.add.sprite(240,640,key).setOrigin(0.5,1).setScale(0.15).setDepth(1);
     this.tweens.add({ targets: currentCustomer, y:300, duration:1000,
       onComplete: showDialog, callbackScope: this });
   }


### PR DESCRIPTION
## Summary
- enlarge the minigame iframe to fill the screen
- set minigame background to match phone
- enlarge truck and customer sprites
- hide and stop phone messages when the minigame is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865b22f0448832fa5504c3243bec2e5