### PR TITLE
Adjust minigame layout and sprite size

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,8 @@
         width: 480px;
         height: 640px;
         left: 50%;
-        top: 5%;
+        /* Shift the mini game container downward by 100px */
+        top: calc(5% + 100px);
         transform: translate(-50%, 0);
         border: none;
         display: none;

--- a/version1.html
+++ b/version1.html
@@ -132,9 +132,11 @@ window.onload = function() {
     currentRequest = currentCoins < COFFEE_COST ? 'water':'coffee';
     const key = Phaser.Utils.Array.GetRandom(['genz1','genz2','genz3']);
     // Customer sprites are small so scale them up for visibility (slightly reduced)
+    // GenZ2 should appear twice as large as the others
+    const scale = key === 'genz2' ? 6.3 : 3.15;
     currentCustomer = this.add.sprite(240,640,key)
       .setOrigin(0.5,1)
-      .setScale(3.15)
+      .setScale(scale)
       .setDepth(1);
     this.tweens.add({ targets: currentCustomer, y:300, duration:1000,
       onComplete: showDialog, callbackScope: this });


### PR DESCRIPTION
## Summary
- move the minigame iframe lower on the page
- make the GenZ2 sprite twice as large as the others

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865bef5cb74832f8531dbf15c2cef7b