### PR TITLE
Spawn minigame cup from explosion and scale

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -80,7 +80,9 @@ function playOpening(scene){
       });
     }
     // Spawn the minigame button cup during the explosion
-    miniGameCup = scene.add.image(openingNumber.x, openingNumber.y, 'coffeecup2')
+    // Position it where the "2" lands so it bursts from the right
+    miniGameCup = scene.add
+      .image(finalX, finalY, 'coffeecup2')
       .setDepth(17)
       .setScale(1);
   }, []);
@@ -265,6 +267,7 @@ function showStartScreen(scene){
       targets: miniGameCup,
       x: 0,
       y: offsetY - bh - 20,
+      scale: 1,
       duration: 800,
       ease: 'Bounce.easeOut',
       onComplete: () => {


### PR DESCRIPTION
## Summary
- spawn the minigame button from the coffee explosion
- let the button scale to full size as it lands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865c7d54a1c832f870650710384d44e