### PR TITLE
Adjust mini game cup drop animation

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -268,12 +268,20 @@ function showStartScreen(scene){
     const cupTL = scene.tweens.createTimeline();
     cupTL.add({
       targets: miniGameCup,
-      x: 0,
-      y: offsetY - bh - 20,
+      x: '-=40',
+      y: offsetY - bh - 60,
       scale: 1,
       alpha: 1,
+      angle: -180,
+      duration: 500,
+      ease: 'Cubic.easeOut'
+    });
+    cupTL.add({
+      targets: miniGameCup,
+      x: 0,
+      y: offsetY - bh - 20,
       angle: -360,
-      duration: 800,
+      duration: 300,
       ease: 'Bounce.easeOut'
     });
     cupTL.add({ targets: miniGameCup, angle: -15, duration: 120, ease: 'Sine.easeInOut' });


### PR DESCRIPTION
## Summary
- tweak the mini game cup tween so it curves left and rotates counter-clockwise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865cf0c378c832f9f3b306c63aadd7e