### PR TITLE
Fix minigame scaling on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,14 @@
       }
       #version1-frame {
         position: absolute;
-        width: 480px;
-        height: 640px;
         left: 50%;
         /* Shift the mini game container downward by 130px */
         top: calc(5% + 130px);
         transform: translate(-50%, 0);
+        width: 100%;
+        max-width: 480px;
+        aspect-ratio: 3 / 4; /* keep 480x640 ratio */
+        height: auto;
         border: none;
         display: none;
         z-index: 100;


### PR DESCRIPTION
## Summary
- keep the mini game iframe aspect ratio but allow it to shrink on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865d0f0c974832f8ce77c2d52fc344d