### PR TITLE
Kill active cup tweens on start screen

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -266,6 +266,9 @@ function showStartScreen(scene){
 
   // Mini game cup drops into place above the Clock In button
   if (miniGameCup) {
+    if (scene.tweens && scene.tweens.killTweensOf) {
+      scene.tweens.killTweensOf(miniGameCup);
+    }
     const pcScale = phoneContainer.scale || phoneContainer.scaleX || 1;
     const m = phoneContainer.getWorldTransformMatrix();
     const localX = (miniGameCup.x - m.tx) / m.a;


### PR DESCRIPTION
## Summary
- prevent leftover tweens from moving the minigame cup when showing start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865e769d12c832f99e10c7be9edf61c