### PR TITLE
Keep minigame visible during phone exit

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -502,7 +502,6 @@ function showStartScreen(scene){
   }
   startZone.on('pointerdown',()=>{
     // Disable further clicks as soon as the intro begins
-    if (window.hideMiniGame) window.hideMiniGame();
     startZone.disableInteractive();
     if (phoneContainer && phoneContainer.disableInteractive) {
       phoneContainer.disableInteractive();
@@ -518,6 +517,7 @@ function showStartScreen(scene){
       spawnSparrow(scene,{ground:true});
     }
     const tl=scene.tweens.createTimeline({callbackScope:scene,onComplete:()=>{
+      if (window.hideMiniGame) window.hideMiniGame();
       if(startButton) startButton.destroy();
       if(startOverlay){startOverlay.destroy(); startOverlay=null;}
       if(startWhite){startWhite.destroy(); startWhite=null;}


### PR DESCRIPTION
## Summary
- avoid hiding the minigame the instant the Clock In button is pressed
- destroy the minigame once the phone has slid offscreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866db2c50fc832fb5effec98717c6be