### PR TITLE
Make falcon attack scatter sparrows

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2523,7 +2523,11 @@ export function setupGame(){
     cleanupBarks();
     cleanupBursts();
     cleanupSparkles(scene);
-    cleanupSparrows(scene);
+    scatterSparrows(scene);
+    if(scene.gameState.sparrowSpawnEvent){
+      scene.gameState.sparrowSpawnEvent.remove(false);
+      scene.gameState.sparrowSpawnEvent = null;
+    }
     hideOverlayTexts();
     clearDialog.call(scene);
     GameState.falconActive = true;


### PR DESCRIPTION
## Summary
- let sparrows fly away during falcon attack
- stop any pending sparrow spawns when the attack begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e64b01f8832f998f10aa739bac59