### PR TITLE
Fix dog death visuals and unify dog scale

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -15,10 +15,11 @@ export const DOG_TYPES = [
   // scale represents relative size compared to a customer sprite
   // all dogs are smaller; the largest is now the old "service" size
   // tints use more subdued dog-like colors
+  // use a uniform base size for all dogs
   { type: 'standard', emoji: '🐶', tint: 0x996633, scale: 0.4 }, // brown
-  { type: 'poodle',   emoji: '🐩', tint: 0xdddddd, scale: 0.37 }, // white/gray
-  { type: 'guide',    emoji: '🦮', tint: 0x444444, scale: 0.34 }, // dark
-  { type: 'service',  emoji: '🐕‍🦺', tint: 0xbb8844, scale: 0.31 } // tan
+  { type: 'poodle',   emoji: '🐩', tint: 0xdddddd, scale: 0.4 }, // white/gray
+  { type: 'guide',    emoji: '🦮', tint: 0x444444, scale: 0.4 }, // dark
+  { type: 'service',  emoji: '🐕‍🦺', tint: 0xbb8844, scale: 0.4 } // tan
 ];
 
 export function barkLevel(dog){

--- a/src/main.js
+++ b/src/main.js
@@ -3109,7 +3109,8 @@ function dogsBarkAtFalcon(){
             onComplete: () => {
               if(dog.anims && dog.anims.stop) dog.anims.stop();
               else if(dog.anims && dog.anims.pause) dog.anims.pause();
-              dog.setTint(0x888888);
+              // leave the dog permanently gray when defeated
+              dog.setTint(0x808080);
               scene.tweens.add({
                 targets: dog,
                 y: DOG_MIN_Y,
@@ -3123,6 +3124,7 @@ function dogsBarkAtFalcon(){
                   ensureOnGround(dog);
                   dog.attacking = false;
                   dog.dead = true;
+                  dog.setAngle(180);
                   const rIdx = reinDogs.indexOf(dog);
                   if(rIdx !== -1) reinDogs.splice(rIdx, 1);
                   if(done) done();


### PR DESCRIPTION
## Summary
- keep all dog types the same size
- tint defeated dogs gray and leave them belly-up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e9a8ede0832fb664ef453df78b71