### PR TITLE
Fix minigame iframe and ensure phone exit alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
       f.style.width = `${screenW * scaleX}px`;
       f.style.height = `${screenH * scaleY}px`;
     }
+    window.positionMiniGame = positionMiniGame;
     window.showMiniGame = function() {
       const f = document.getElementById('version1-frame');
       if (f) {

--- a/src/game.js
+++ b/src/game.js
@@ -14,6 +14,7 @@ export function startGame() {
 
 // Start the game immediately when loaded in a browser
 if (typeof window !== 'undefined') {
+  window.GameState = GameState;
   startGame();
 }
 

--- a/src/intro.js
+++ b/src/intro.js
@@ -533,7 +533,17 @@ function showStartScreen(scene){
       GameState.phoneContainer = null;
       playIntro.call(scene);
     }});
-    tl.add({targets:phoneContainer,y:-320,duration:600,ease:'Sine.easeIn'});
+    tl.add({
+      targets: phoneContainer,
+      y: -320,
+      duration: 600,
+      ease: 'Sine.easeIn',
+      onUpdate: () => {
+        if (window.minigameActive && window.positionMiniGame) {
+          window.positionMiniGame();
+        }
+      }
+    });
     const fadeTargets = [startOverlay, openingTitle, openingNumber, openingDog].filter(Boolean);
     if (fadeTargets.length) {
       tl.add({targets:fadeTargets,alpha:0,duration:600});


### PR DESCRIPTION
## Summary
- expose `GameState` on `window`
- make minigame positioning function callable globally
- reposition iframe while the phone container animates off-screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68670744166c832fb3d3e25009e9d32d