### PR TITLE
Add fired ending and Gen Z reminders

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','falcon_victory','revolt_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','falcon_victory','revolt_end','fired_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -90,6 +90,7 @@ export function preload(){
   loader.image('title2','assets/title2.png');
   loader.spritesheet('lady_falcon','assets/lady_falcon.png',{frameWidth:64,frameHeight:64});
   loader.image('falcon_end','assets/ladyfalconend.png');
+  loader.image('fired_end','assets/FiredN.png');
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('revolt_end','assets/revolt.png');

--- a/src/customers.js
+++ b/src/customers.js
@@ -42,6 +42,8 @@ export const MAX_WANDERERS = 5;
 export const WALK_OFF_BASE = 800;
 export const MAX_M = 200;
 export const MAX_L = 100;
+// Money threshold that triggers the fired ending
+export const FIRED_THRESHOLD = 100;
 
 // Queue capacity is determined directly from the player's heart count in
 // `queueLimit`. There is no longer a separate base limit constant.

--- a/src/intro.js
+++ b/src/intro.js
@@ -327,7 +327,8 @@ function showStartScreen(scene){
   const badgeScale = 0.3;
   const badgeSlots = {
     falcon_end: { x: -60, y: iconY },
-    revolt_end: { x:  60, y: iconY }
+    revolt_end: { x:  60, y: iconY },
+    fired_end: { x:   0, y: iconY }
   };
   const iconStartX = -phoneW/2 + 30; // fallback for unknown badges
   GameState.badges.forEach((key, idx) => {
@@ -497,9 +498,17 @@ function showStartScreen(scene){
       ['keep em happy or they\'ll riot again', 'learn and be cooler next shift', 'better customer vibes or bust', 'make ppl happy, avoid another revolt']
     ];
 
+    const firedMsgs=[
+      ['u really handed the corp all ur $$', 'overlord vibes much?', 'did they at least say thx?', 'bro you got fired at 100'],
+      ['keep some of that cash for urself', 'stop feeding the corporate machine', 'seriously did u ask for ur job back?', "can't just give away all ur worth"],
+      ['capitalism 101: hoard ur coins', 'no more freebies 4 the boss', 'maybe start ur own thing?', 'so, did they rehire u?'],
+      ['remember ur value!', "don't let them take it all", 'get that job back or bounce', 'gen z would revolt']
+    ];
+
     let msgOptions = defaultMsgs;
     if(GameState.lastEndKey === 'falcon_end') msgOptions = falconMsgs;
     else if(GameState.lastEndKey === 'revolt_end') msgOptions = revoltMsgs;
+    else if(GameState.lastEndKey === 'fired_end') msgOptions = firedMsgs;
 
     let delay=0;
     for(const opts of msgOptions){

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { debugLog, DEBUG } from './debug.js';
 import { dur, scaleForY, articleFor, flashMoney, BUTTON_Y, DIALOG_Y, setSpeedMultiplier } from "./ui.js";
-import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, queueLimit, RESPAWN_COOLDOWN } from "./customers.js";
+import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, FIRED_THRESHOLD, queueLimit, RESPAWN_COOLDOWN } from "./customers.js";
 import { lureNextWanderer, moveQueueForward, scheduleNextSpawn, spawnCustomer, startDogWaitTimer } from './entities/customerQueue.js';
 import { baseConfig } from "./scene.js";
 import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from "./state.js";
@@ -1842,7 +1842,7 @@ export function setupGame(){
           });
           return;
         }
-        if(GameState.money>=MAX_M){
+        if(GameState.money>=FIRED_THRESHOLD){
           showHighMoneyLoss.call(this);
           return;
         }
@@ -3889,6 +3889,12 @@ function dogsBarkAtFalcon(){
     }).setOrigin(0.5).setDepth(20).setAlpha(0);
     this.tweens.add({targets:[titleGame,titleOver],alpha:1,duration:dur(1200)});
 
+    const img = this.add.image(240,250,'fired_end')
+      .setScale(1.2)
+      .setDepth(20)
+      .setAlpha(0);
+    this.tweens.add({targets:img,alpha:1,duration:dur(1200),delay:dur(1000)});
+
     const line1 = this.add.text(240,450,'LADY FALCON COFFEE SUCCEEDS.',
       {font:'28px sans-serif',fill:'#fff',align:'center',wordWrap:{width:440}})
       .setOrigin(0.5)
@@ -3915,6 +3921,11 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
+        GameState.lastEndKey = 'fired_end';
+        if(!GameState.badges.includes('fired_end')) GameState.badges.push('fired_end');
+        GameState.badgeCounts['fired_end'] = (GameState.badgeCounts['fired_end'] || 0) + 1;
+        createGrayscaleTexture(this,'fired_end','fired_end_gray');
+        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -3930,6 +3941,7 @@ function dogsBarkAtFalcon(){
           onComplete:()=>{
             titleGame.destroy();
             titleOver.destroy();
+            img.destroy();
             line1.destroy();
             line2.destroy();
             btn.destroy();


### PR DESCRIPTION
## Summary
- trigger a new fired ending once the player earns $100
- add FiredN.png asset and preload it
- show a badge for the fired ending and Gen Z style follow-up messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68671093d020832f8c8efdbabf1c1089