### PR TITLE
Fix dog tint and add pup cup glow

### DIFF
--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -594,8 +594,7 @@ export function spawnCustomer() {
     const offsetY = Phaser.Math.Between(10, 20);
     const dogType = DOG_TYPES.find(d => d.type === memory.dogMemory.type) || Phaser.Utils.Array.GetRandom(DOG_TYPES);
     const dog = this.add.sprite(startX + offsetX, startY + offsetY, 'dog1', 1)
-      .setOrigin(0.5)
-      .setTint(dogType.tint || 0xffffff);
+      .setOrigin(0.5);
     if (DEBUG && dog.setInteractive) {
       dog.setInteractive({ useHandCursor: true });
       dog.on('pointerdown', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from
 import { CustomerState } from './constants.js';
 
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows, scatterSparrows } from './sparrow.js';
-import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark, dogBarkAt, animateDogPowerUp, barkProps } from './entities/dog.js';
+import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark, dogBarkAt, animateDogPowerUp, barkProps, PUP_CUP_TINT } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
 
 import { flashBorder, flashFill, blinkButton, applyRandomSkew, setDepthFromBottom, createGrayscaleTexture, createGlowTexture, createHpBar } from './ui/helpers.js';
@@ -1453,7 +1453,7 @@ export function setupGame(){
           tl.add({ targets: dialogDrinkEmoji, scale: 0, duration: dur(150), ease:'Cubic.easeIn' });
           tl.add({ targets: dialogDrinkEmoji, alpha:0, duration: dur(80) });
           tl.setCallback('onComplete', () => {
-            animateDogPowerUp(this, target, react);
+            animateDogPowerUp(this, target, react, PUP_CUP_TINT);
           }, []);
           tl.play();
         } else if (this.time) {
@@ -3629,7 +3629,6 @@ function dogsBarkAtFalcon(){
           const dType = DOG_TYPES.find(d => d.type === mem.dogMemory.type) || { scale: 0.4, tint: 0xffffff };
           const dog = scene.add.sprite(dx, dy, 'dog1',1)
             .setOrigin(0.5)
-            .setTint(dType.tint || 0xffffff)
             .setDepth(20);
           dog.baseScaleFactor = dType.scale || 0.4;
           dog.scaleFactor = dog.baseScaleFactor;


### PR DESCRIPTION
## Summary
- remove default brown tint from dogs when they spawn
- keep stray dogs untinted
- add `PUP_CUP_TINT` constant and glow logic
- apply warm yellow tint and glow when a dog receives a pup cup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867157a2824832f82b4b5b490e09f24