### PR TITLE
Add achievement grid UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ an error if your Node version doesn't match `22.x`.
 
    This runs `http-server` on `http://localhost:8080`. Open that URL in your browser.
 
-   Click **Clock In** when it appears to begin the game.
+  Click **Clock In** when it appears to begin the game.
+
+  Achievements now appear as small icons on the phone screen. The screen
+  shows six soft gray slots arranged in two rows of three. The mini game
+  coffee cup lands in the bottom-left slot and each ending you reach fills
+  a slot with its portrait, including a count if you repeat that ending.
 
   The game now loads `src/game.js` as an ES module using
   `<script type="module" src="src/game.js"></script>` in `index.html`. If the page


### PR DESCRIPTION
## Summary
- add grid of icon slots on the phone start screen
- animate mini game cup into the bottom-left slot
- show earned ending icons in the grid with repeat counts
- document new achievement slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68671ae29234832fb54e87624c3b4daa