### PR TITLE
Fix icon alignment near Clock In button

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -275,7 +275,10 @@ function showStartScreen(scene){
   const marginX = (phoneW - 24 - cols*slotSize) / (cols+1);
   const marginY = 40;
   const startX = -phoneW/2 + 12 + marginX + slotSize/2;
-  const startY = -phoneH/2 + 12 + marginY + slotSize/2;
+  // Align the slots relative to the bottom of the phone so they appear
+  // just above the "Clock In" button instead of hugging the top.
+  const startY =
+    offsetY - bh / 2 - marginY - (rows - 1) * (slotSize + marginY) - slotSize / 2;
   for(let r=0;r<rows;r++){
     for(let c=0;c<cols;c++){
       const x = startX + c*(slotSize+marginX);


### PR DESCRIPTION
## Summary
- align icon slots above "Clock In" button instead of top of phone

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68671da24dd0832f9db26660ecf12b01