### PR TITLE
Fix missing getSlot function

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -20,6 +20,12 @@ let badgeIcons = [];
 let iconSlots = [];
 let miniGameCup = null;
 
+function getSlot(idx){
+  if(!iconSlots.length) return { x: 0, y: 0 };
+  const clamped = Math.max(0, Math.min(idx, iconSlots.length - 1));
+  return iconSlots[clamped];
+}
+
 function hideStartMessages(){
   startMsgTimers.forEach(t=>t.remove(false));
   startMsgTimers=[];


### PR DESCRIPTION
## Summary
- add getSlot helper used by start screen animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686720cc6278832f828f93ec1b7214bf