### PR TITLE
Reset drink emoji alpha for new orders

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1101,6 +1101,9 @@ export function setupGame(){
         dialogPriceTicket.setTexture('price_ticket');
       }
     }
+    if(dialogDrinkEmoji && dialogDrinkEmoji.setAlpha){
+      dialogDrinkEmoji.setAlpha(1);
+    }
   }
 
   function showDialog(){
@@ -1130,6 +1133,10 @@ export function setupGame(){
         console.warn(`showDialog skipped: missing ${missingElems.join(', ')}`);
       }
       return;
+    }
+    // Reset ticket visuals in case previous animations modified them
+    if (typeof resetPriceBox === 'function') {
+      resetPriceBox.call(this);
     }
     // reset the dialog position in case previous animations moved it
     dialogBg.y = typeof DIALOG_Y === 'number' ? DIALOG_Y : 430;


### PR DESCRIPTION
## Summary
- reset price ticket visuals at the start of each dialog
- ensure drink emoji alpha returns to 1 when resetting the ticket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68672e824c2c832f875f8b2e1d744e42