### PR TITLE
Add Love Victory End Screen

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','falcon_victory','revolt_end','fired_end','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','falcon_victory','revolt_end','fired_end','muse_victory','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -93,6 +93,7 @@ export function preload(){
   loader.image('fired_end','assets/firedend.png');
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
+  loader.image('muse_victory','assets/musevictory.png');
   loader.image('revolt_end','assets/revolt.png');
   loader.image('price_ticket','assets/priceticket.png');
   loader.image('pupcup','assets/pupcup.png');

--- a/src/intro.js
+++ b/src/intro.js
@@ -590,7 +590,7 @@ function showStartScreen(scene){
 
     let msgOptions = defaultMsgs;
     if(GameState.lastEndKey === 'falcon_end') msgOptions = falconMsgs;
-    else if(GameState.lastEndKey === 'falcon_victory') msgOptions = victoryMsgs;
+    else if(GameState.lastEndKey === 'falcon_victory' || GameState.lastEndKey === 'muse_victory') msgOptions = victoryMsgs;
     else if(GameState.lastEndKey === 'revolt_end') msgOptions = revoltMsgs;
     else if(GameState.lastEndKey === 'fired_end') msgOptions = firedMsgs;
 


### PR DESCRIPTION
## Summary
- load `muse_victory` graphic
- introduce `showLoveVictory` sequence triggered at 100 love
- treat `muse_victory` like other wins in intro dialog
- remove unused `showEnd` function

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68674631a590832f9bd9fcc541bc9a9a