### PR TITLE
Add Professor Coffee hint system

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -37,6 +37,7 @@ export const GameState = {
   ,activeBursts: []
   ,victoryOverlay: null
   ,falconDefeated: false
+  ,profHintUsed: false
 };
 
 export const floatingEmojis = [];


### PR DESCRIPTION
## Summary
- add Professor Coffee hint feature
- show all achievement icons and highlight earned ones
- tint mini game cup gold
- fade start screen messages and limit display
- track hint usage in game state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867784611e8832faabf8cbdb70eca3a