### PR TITLE
Add fullscreen toggle

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -2,6 +2,7 @@ import { GameState } from './state.js';
 import * as CustomerQueue from './entities/customerQueue.js';
 import * as Dog from './entities/dog.js';
 import { setupGame, showStartScreen, handleAction, spawnCustomer, scheduleNextSpawn, showDialog, animateLoveChange, blinkButton } from './main.js';
+import { addFullscreenButton } from './ui/fullscreen.js';
 
 // Initialize the Phaser game scene using main.js logic
 export function startGame() {
@@ -10,6 +11,7 @@ export function startGame() {
   void CustomerQueue;
   void Dog;
   setupGame();
+  addFullscreenButton();
 }
 
 // Start the game immediately when loaded in a browser

--- a/src/ui/fullscreen.js
+++ b/src/ui/fullscreen.js
@@ -1,0 +1,43 @@
+export function addFullscreenButton(){
+  if(typeof document==='undefined') return;
+  const container=document.getElementById('game-container');
+  if(!container) return;
+  if(document.getElementById('fullscreen-btn')) return;
+  container.style.position='relative';
+  const btn=document.createElement('button');
+  btn.id='fullscreen-btn';
+  btn.textContent='\u26F6';
+  Object.assign(btn.style,{
+    position:'absolute',
+    right:'8px',
+    bottom:'8px',
+    width:'32px',
+    height:'32px',
+    padding:'0',
+    background:'rgba(0,0,0,0.5)',
+    color:'#fff',
+    border:'none',
+    borderRadius:'4px',
+    cursor:'pointer',
+    zIndex:'20',
+    fontSize:'20px',
+    lineHeight:'32px',
+    textAlign:'center'
+  });
+  container.appendChild(btn);
+  function toggle(){
+    if(document.fullscreenElement){
+      if(document.exitFullscreen) document.exitFullscreen();
+    }else if(container.requestFullscreen){
+      container.requestFullscreen();
+    }
+  }
+  btn.addEventListener('click',toggle);
+  document.addEventListener('fullscreenchange',()=>{
+    btn.textContent=document.fullscreenElement?'\u2715':'\u26F6';
+    const game=window.Phaser&&window.Phaser.GAMES&&window.Phaser.GAMES[0];
+    if(game&&game.scale&&game.scale.refresh){
+      game.scale.refresh();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add `addFullscreenButton` helper that injects a fullscreen button and refreshes Phaser scale
- call new helper when the game starts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686835e03690832fb8dc922a92cc2fd7