### PR TITLE
Remove Professor Coffee and adjust achievements

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -37,7 +37,6 @@ export const GameState = {
   ,activeBursts: []
   ,victoryOverlay: null
   ,falconDefeated: false
-  ,profHintUsed: false
 };
 
 export const floatingEmojis = [];


### PR DESCRIPTION
## Summary
- eliminate `Professor Coffee` hint system and related state
- reorder achievement slots
- show golden cup in top-left slot only after all achievements are earned

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686842674134832f9a46dcc04e368993