### PR TITLE
Improve phone start screen

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -37,6 +37,8 @@ export const GameState = {
   ,activeBursts: []
   ,victoryOverlay: null
   ,falconDefeated: false
+  ,slotsRevealed: false
+  ,startScreenSeen: false
   ,achievementsRevealed: false
 };
 


### PR DESCRIPTION
## Summary
- track whether the start screen has been seen
- hide achievement slots on first visit, fade them in later
- show faint coffee cup outline in the empty top-left slot

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686846ff5628832fb0ddc5daa6cd2baf