### PR TITLE
Fix restart bug destroying cupShadow

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -191,6 +191,14 @@ function playOpening(scene){
 function showStartScreen(scene){
   scene = scene || this;
   if (typeof debugLog === 'function') debugLog('showStartScreen called');
+  // `cupShadow` is destroyed when the phone container is removed but the
+  // variable persists between runs. If we try to re-add the old destroyed
+  // object, Phaser throws a "Cannot read properties of undefined" error when
+  // it attempts to access `sys` on the dead game object. Guard against this by
+  // clearing any lingering reference before creating the new start screen.
+  if (cupShadow && !cupShadow.scene) {
+    cupShadow = null;
+  }
   if(startButton){ startButton.destroy(); startButton = null; }
   if(typeof phoneContainer !== 'undefined' && phoneContainer){
     if(scene.tweens && scene.tweens.killTweensOf){


### PR DESCRIPTION
## Summary
- fix crash when restarting the game by clearing destroyed `cupShadow`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68684a392378832f8e9dbf3a96c3f958