### PR TITLE
Fix achievement loss recording

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -288,6 +288,16 @@ export function setupGame(){
     if(lossStamp) lossStamp.setVisible(false);
   }
 
+  // Record an achievement immediately when an ending is shown
+  function awardBadge(scene, key){
+    if(!key) return;
+    GameState.lastEndKey = key;
+    if(!GameState.badges.includes(key)) GameState.badges.push(key);
+    GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
+    const grayKey = `${key}_gray`;
+    createGrayscaleTexture(scene, key, grayKey);
+  }
+
 
   function fadeInButtons(canSell){
     const startY = BUTTON_Y + 50;
@@ -3984,6 +3994,7 @@ function dogsBarkAtFalcon(){
       .setDepth(20)
       .setAlpha(0);
     this.tweens.add({targets:img,alpha:1,duration:dur(1200)});
+    awardBadge(this, img.texture.key);
 
     const line1 = this.add.text(240,450,'YOU ARE THE MUSE',
       {font:'28px sans-serif',fill:'#fff'})
@@ -4011,15 +4022,7 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        const key = img ? img.texture.key : null;
-        if(key){
-          GameState.lastEndKey = key;
-          if(!GameState.badges.includes(key)) GameState.badges.push(key);
-          GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
-          const grayKey = `${key}_gray`;
-          createGrayscaleTexture(this,key,grayKey);
-          GameState.carryPortrait = img.setDepth(25);
-        }
+        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -4075,6 +4078,7 @@ function dogsBarkAtFalcon(){
       .setDepth(20)
       .setAlpha(0);
     this.tweens.add({targets:img,alpha:1,duration:dur(1200),delay:dur(1000)});
+    awardBadge(this, img.texture.key);
 
     const line1 = this.add.text(240,450,'LADY FALCON WINS',
       {font:'28px sans-serif',fill:'#fff',align:'center',wordWrap:{width:440}})
@@ -4102,10 +4106,6 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        GameState.lastEndKey = 'fired_end';
-        if(!GameState.badges.includes('fired_end')) GameState.badges.push('fired_end');
-        GameState.badgeCounts['fired_end'] = (GameState.badgeCounts['fired_end'] || 0) + 1;
-        createGrayscaleTexture(this,'fired_end','fired_end_gray');
         GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
@@ -4164,6 +4164,7 @@ function dogsBarkAtFalcon(){
       .setDepth(20)
       .setAlpha(0);
     this.tweens.add({targets:img,alpha:1,duration:dur(1200),delay:dur(1000)});
+    awardBadge(this, img.texture.key);
 
     const line1 = this.add.text(240,450,'YOU LOST ALL THE MONEY',
       {font:'28px sans-serif',fill:'#fff'})
@@ -4195,15 +4196,7 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        const key = img ? img.texture.key : null;
-        if(key){
-          GameState.lastEndKey = key;
-          if(!GameState.badges.includes(key)) GameState.badges.push(key);
-          GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
-          const grayKey = `${key}_gray`;
-          createGrayscaleTexture(this,key,grayKey);
-          GameState.carryPortrait = img.setDepth(25);
-        }
+        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -4265,6 +4258,7 @@ function dogsBarkAtFalcon(){
       .setDepth(21)
       .setAlpha(0);
     this.tweens.add({targets:img,alpha:1,duration:fadeDur});
+    awardBadge(this, img.texture.key);
 
     const line1 = this.add.text(240,450,'LADY FALCON DEFEATED',
       {font:'28px sans-serif',fill:'#fff'})
@@ -4311,15 +4305,7 @@ function dogsBarkAtFalcon(){
 
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        const key = img ? img.texture.key : null;
-        if(key){
-          GameState.lastEndKey = key;
-          if(!GameState.badges.includes(key)) GameState.badges.push(key);
-          GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
-          const grayKey = `${key}_gray`;
-          createGrayscaleTexture(this,key,grayKey);
-          GameState.carryPortrait = img.setDepth(25);
-        }
+        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         if(overlay){ this.tweens.add({targets:overlay,alpha:0,duration:dur(600)}); }
         createGlowTexture(this,0xffffff,'screen_flash',256);
@@ -4381,6 +4367,7 @@ function dogsBarkAtFalcon(){
       .setDepth(20)
       .setAlpha(0);
     this.tweens.add({targets:img,alpha:1,duration:dur(1200),delay:dur(1000)});
+    awardBadge(this, img.texture.key);
 
     const line1 = this.add.text(240,450,'THE CUSTOMERS REVOLT!',
       {font:'28px sans-serif',fill:'#fff'})
@@ -4413,15 +4400,7 @@ function dogsBarkAtFalcon(){
 
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        const key = img ? img.texture.key : null;
-        if(key){
-          GameState.lastEndKey = key;
-          if(!GameState.badges.includes(key)) GameState.badges.push(key);
-          GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
-          const grayKey = `${key}_gray`;
-          createGrayscaleTexture(this,key,grayKey);
-          GameState.carryPortrait = img.setDepth(25);
-        }
+        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);


### PR DESCRIPTION
## Summary
- add an `awardBadge` helper to track endings immediately
- call `awardBadge` when showing each game over screen
- keep only the restart animation on button press

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686853067928832f81afac06e06c0004