### PR TITLE
Persist achievements

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,4 +1,4 @@
-import { GameState } from './state.js';
+import { GameState, loadAchievements } from './state.js';
 import * as CustomerQueue from './entities/customerQueue.js';
 import * as Dog from './entities/dog.js';
 import { setupGame, showStartScreen, handleAction, spawnCustomer, scheduleNextSpawn, showDialog, animateLoveChange, blinkButton } from './main.js';
@@ -9,6 +9,7 @@ export function startGame() {
   void GameState;
   void CustomerQueue;
   void Dog;
+  loadAchievements();
   setupGame();
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import { dur, scaleForY, articleFor, flashMoney, BUTTON_Y, DIALOG_Y, setSpeedMul
 import { ORDER_X, ORDER_Y, WANDER_TOP, WANDER_BOTTOM, WALK_OFF_BASE, MAX_M, MAX_L, FIRED_THRESHOLD, queueLimit, RESPAWN_COOLDOWN } from "./customers.js";
 import { lureNextWanderer, moveQueueForward, scheduleNextSpawn, spawnCustomer, startDogWaitTimer } from './entities/customerQueue.js';
 import { baseConfig } from "./scene.js";
-import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji } from "./state.js";
+import { GameState, floatingEmojis, addFloatingEmoji, removeFloatingEmoji, saveAchievements } from "./state.js";
 import { CustomerState } from './constants.js';
 
 import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows, scatterSparrows } from './sparrow.js';
@@ -307,6 +307,7 @@ export function setupGame(){
     GameState.lastEndKey = key;
     if(!GameState.badges.includes(key)) GameState.badges.push(key);
     GameState.badgeCounts[key] = (GameState.badgeCounts[key] || 0) + 1;
+    if (typeof saveAchievements === 'function') saveAchievements();
     const grayKey = `${key}_gray`;
     createGrayscaleTexture(scene, key, grayKey);
   }

--- a/src/state.js
+++ b/src/state.js
@@ -55,3 +55,28 @@ export function removeFloatingEmoji(emoji) {
   const idx = floatingEmojis.indexOf(emoji);
   if (idx !== -1) floatingEmojis.splice(idx, 1);
 }
+
+export function loadAchievements() {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    const raw = window.localStorage.getItem('coffeeGirlAchievements');
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    if (Array.isArray(data.badges)) GameState.badges = data.badges.slice();
+    if (data.badgeCounts && typeof data.badgeCounts === 'object') {
+      GameState.badgeCounts = { ...data.badgeCounts };
+    }
+  } catch (err) {
+    // ignore malformed storage
+  }
+}
+
+export function saveAchievements() {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    const data = { badges: GameState.badges, badgeCounts: GameState.badgeCounts };
+    window.localStorage.setItem('coffeeGirlAchievements', JSON.stringify(data));
+  } catch (err) {
+    // ignore quota errors
+  }
+}


### PR DESCRIPTION
## Summary
- store badges using localStorage
- load saved achievements when starting the game
- persist on award

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68685769f3e0832f85d8820534f29f54