### PR TITLE
Add classic+reset controls with new cup row

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
     window.showMiniGame = function() {
       const f = document.getElementById('version1-frame');
       if (f) {
-        if (window.hideStartMessages) window.hideStartMessages();
+        if (window.hideStartScreen) window.hideStartScreen();
         window.minigameActive = true;
         f.src = 'version1.html';
         positionMiniGame();

--- a/src/state.js
+++ b/src/state.js
@@ -80,3 +80,15 @@ export function saveAchievements() {
     // ignore quota errors
   }
 }
+
+export function resetAchievements() {
+  GameState.badges = [];
+  GameState.badgeCounts = {};
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      window.localStorage.removeItem('coffeeGirlAchievements');
+    } catch (err) {
+      // ignore quota errors
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent resetAchievements helper
- reposition minigame cup to a dedicated third row
- disable cup interaction and add Classic/Reset buttons
- add Reincarnate confirmation message with eerie glow
- hide start screen when launching the minigame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686861bea69c832f861e63cc4fa9934a