### PR TITLE
Fix crash on start screen

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -379,7 +379,9 @@ function showStartScreen(scene){
     cupShadow.destroy();
     cupShadow = null;
   }
-  cupSlot.setVisible(allEarned);
+  // cupSlot is just a plain coordinate object, so calling setVisible
+  // on it causes errors. Visibility is controlled by the cup and
+  // shadow sprites instead.
   if (allEarned) {
     const glowKey = `gold_glow_${slotSize}`;
     if(!scene.textures.exists(glowKey)) createGlowTexture(scene,0xffd700,glowKey,slotSize);


### PR DESCRIPTION
## Summary
- remove stray `setVisible` call on a plain object in the intro

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686865167364832f9bfbc60910aaba33