### PR TITLE
Fix stray dog cleanup and badge display

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -537,6 +537,19 @@ export function cleanupDogs(scene){
         sendDogOffscreen.call(scene, child, targetX, child.y);
       }
     });
+    // Immediately destroy dogs lingering well beyond the screen edges
+    scene.children.list.slice().forEach(child=>{
+      if(child.texture && child.texture.key==='dog1'){
+        const offX = child.x < -60 || child.x > 540;
+        const offY = child.y > 660;
+        if(offX || offY){
+          if(child.followEvent) child.followEvent.remove(false);
+          if(child.pupGlow) child.pupGlow.destroy();
+          if(child.heartEmoji) child.heartEmoji.destroy();
+          child.destroy();
+        }
+      }
+    });
   }
 }
 

--- a/src/intro.js
+++ b/src/intro.js
@@ -272,12 +272,15 @@ function showStartScreen(scene){
   const containerY = 320;
   phoneContainer = scene.add
     .container(240, containerY, [caseG, blackG, whiteG, homeG])
-    .setDepth(15)
+    .setDepth(20)
     .setVisible(true)
     .setAlpha(1)
     .setSize(phoneW + 20, phoneH + 20)
     .setInteractive({ useHandCursor: true })
     .setScale(2);
+  if(scene.children && scene.children.bringToTop){
+    scene.children.bringToTop(phoneContainer);
+  }
   if(!phoneContainer.visible || phoneContainer.alpha === 0){
     console.warn('phoneContainer not visible after creation');
   }
@@ -500,12 +503,12 @@ function showStartScreen(scene){
           targets: container,
           x: slot.x,
           y: slot.y,
-          alpha: 0.1,
+          alpha: 0.25,
           duration: 800,
           ease: 'Sine.easeOut'
         });
       } else {
-        container.setAlpha(GameState.badges.length ? 0.1 : 0);
+        container.setAlpha(GameState.badges.length ? 0.25 : 0.25);
       }
     }
     phoneContainer.add(container);


### PR DESCRIPTION
## Summary
- remove dogs that wander far beyond screen bounds
- raise phone container layer and ensure it renders on top
- show placeholder badges more clearly and animate them to 25% opacity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68686bbfdcb4832fbdf829d785b5494f