### PR TITLE
Fix phaser start screen bug

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -222,6 +222,9 @@ function showStartScreen(scene){
   if (cupShadow && !cupShadow.scene) {
     cupShadow = null;
   }
+  if (miniGameCup && !miniGameCup.scene) {
+    miniGameCup = null;
+  }
   if(startButton){ startButton.destroy(); startButton = null; }
   if(classicButton){ classicButton.destroy(); classicButton = null; }
   if(resetButton){ resetButton.destroy(); resetButton = null; }


### PR DESCRIPTION
## Summary
- prevent `showStartScreen` from reusing destroyed `miniGameCup`

## Testing
- `npm test`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68686cdda484832fa20ae64bebef0f4f