### PR TITLE
Improve give ticket animation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2388,9 +2388,10 @@ export function setupGame(){
           }
           tl.add({
             targets: ticket,
-            x: '-=80',
-            angle: '-=90',
-            duration: dur(80),
+            x: '-=60',
+            angle: '-=30',
+            alpha: 0.6,
+            duration: dur(150),
             ease: 'Cubic.easeOut',
             onStart: () => {
               if(!dialogPriceValue.parentContainer){
@@ -2409,21 +2410,22 @@ export function setupGame(){
             targets: ticket,
             props: {
               x: { value: destX, ease: 'Sine.easeIn' },
-              y: { value: destY, ease: 'Quad.easeIn' }
+              y: { value: destY, ease: 'Bounce.easeOut' }
             },
-            angle: '-=270',
+            angle: '-=540',
             scale: 0,
             alpha: 0,
-            duration: dur(600),
+            duration: dur(700),
+            onUpdate:(tw,t)=>{t.skewX=Math.sin(tw.progress*Math.PI*8)*0.05;},
             onStart: () => {
               if(dialogPriceTicket && dialogPriceTicket.setTint){
                 dialogPriceTicket.setTint(0xffffff);
                 this.tweens.addCounter({
                   from:0,
                   to:1,
-                  duration: dur(600),
-                  onUpdate:t=>{
-                    const p=t.getValue();
+                  duration: dur(700),
+                  onUpdate:tween=>{
+                    const p=tween.getValue();
                     const g=Math.round(255*(1-p));
                     dialogPriceTicket.setTint(Phaser.Display.Color.GetColor(255,g,g));
                   }


### PR DESCRIPTION
## Summary
- make the price ticket drift and fade before spinning away
- wobble the ticket as it flies to the money score

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686888ff1fb8832f953a5bcaf3e35d39