### PR TITLE
Fix ticket shadow alignment with truck

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -888,6 +888,12 @@ export function setupGame(){
       .setVisible(false)
       .setScale(truck.scaleX * 1.10, truck.scaleY * 1.20);
     dialogPriceShadow.setMask(ticketShadowMask.createBitmapMask());
+    // keep the mask aligned with the truck as it moves or scales
+    this.events.on('update', () => {
+      if (!ticketShadowMask || !truck) return;
+      ticketShadowMask.setPosition(truck.x, truck.y);
+      ticketShadowMask.setScale(truck.scaleX * 1.10, truck.scaleY * 1.20);
+    });
   }
   createGrayscaleTexture(this, 'price_ticket', 'price_ticket_gray');
   dialogPupCup=this.add.image(0,0,'pupcup2')


### PR DESCRIPTION
## Summary
- keep the bitmap mask synchronized with the truck position and scale

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68688923f058832fa3227755ae674bd2