### PR TITLE
Update achievement unlock logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ an error if your Node version doesn't match `22.x`.
 
   Click **Clock In** when it appears to begin the game.
 
-  Achievements now appear as small icons on the phone screen. The mini game
-  coffee cup lands in the bottom-left slot and new slots fade in as you earn
-  endings, filling from the bottom row to the top. Each portrait shows a
-  count if you repeat that ending.
+  Achievements appear as small icons on the phone screen. Empty slots fade in
+  as you unlock endings, filling from the bottom row to the top. After every
+  badge is earned, a gold coffee cup appears in its own row above the icons to
+  launch the mini game. Its shadow only shows when you're one achievement away.
 
   The game now loads `src/game.js` as an ES module using
   `<script type="module" src="src/game.js"></script>` in `index.html`. If the page


### PR DESCRIPTION
## Summary
- show achievements only after intro fades
- unlock mini game cup only when all badges are earned
- display cup shadow one badge before completion
- document new behavior in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686888913468832fa3666b417c099b31