### PR TITLE
Fix miniGameCup null reference

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -466,7 +466,7 @@ function showStartScreen(scene){
       if(typeof showResetConfirm === 'function') showResetConfirm();
     }, 0x555555);
   } else {
-    miniGameCup.setAlpha(0);
+    if (miniGameCup) miniGameCup.setAlpha(0);
   }
 
   badgeIcons.forEach(i=>i.destroy());


### PR DESCRIPTION
## Summary
- guard against `miniGameCup` being null when hiding the cup on the start screen

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868a915d6b0832f9026cc179a053054