### PR TITLE
Add debug.js documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The game uses [Phaser](https://phaser.io/). It will load `lib/phaser.min.js` by 
 ## Debugging
 
 Append `?debug=1` to the game URL or set `localStorage.DEBUG = '1'` in the
-browser console to enable verbose logging. For example:
+browser console to enable verbose logging. For a full explanation of the helper
+that powers this feature, see [docs/debug-js.md](docs/debug-js.md). For example:
 
 ```
 http://localhost:8080/?debug=1

--- a/docs/debug-js.md
+++ b/docs/debug-js.md
@@ -1,0 +1,45 @@
+# Debug Logging
+
+The game includes a small `src/debug.js` helper that toggles verbose console output. It exports two pieces:
+
+- `DEBUG` – `true` when logging is enabled.
+- `debugLog()` – wrapper around `console.log` that only prints when `DEBUG` is set.
+
+```js
+export const DEBUG = (() => {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('debug') === '1') return true;
+    if (window.localStorage.getItem('DEBUG') === '1') return true;
+  } catch {
+    // ignore
+  }
+  return false;
+})();
+
+export function debugLog(...args) {
+  if (DEBUG) console.log(...args);
+}
+```
+
+## Enabling logging
+
+Open the game with `?debug=1` appended to the URL or set `localStorage.DEBUG = '1'` in the browser console:
+
+```
+http://localhost:8080/?debug=1
+```
+
+Reload the page after setting `localStorage.DEBUG` for the flag to take effect. When either option is active the `DEBUG` constant is `true` and `debugLog()` prints to the console.
+
+## Modules that log output
+
+The following modules check `DEBUG` or call `debugLog()` to emit additional information:
+
+- `src/main.js`
+- `src/dialog.js`
+- `src/intro.js`
+- `src/entities/customerQueue.js`
+- `src/assets.js`
+
+Other modules may read the flag in the future, but these are the primary sources of debug output today.


### PR DESCRIPTION
## Summary
- explain `debug.js` behavior and logging activation
- cross-link README to `docs/debug-js.md`

## Testing
- `npm test` *(fails: `Identifier 'DART_MIN_DURATION' has already been declared`)*

------
https://chatgpt.com/codex/tasks/task_e_6869531ad4a4832fbc93c68e28d0d31a