### PR TITLE
Add dev server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ an error if your Node version doesn't match `22.x`.
    ```bash
    npm install
    npm start
+   # or start with DEBUG=1
+   npm run dev
    ```
 
-   This runs `http-server` on `http://localhost:8080`. Open that URL in your browser.
-
+   Both commands run `http-server` on `http://localhost:8080`. `npm run dev` logs additional debugging information. Open that URL in your browser. 
   Click **Clock In** when it appears to begin the game.
 
   Achievements appear as small icons on the phone screen. Empty slots fade in
@@ -59,12 +60,13 @@ browser console to enable verbose logging. For example:
 http://localhost:8080/?debug=1
 ```
 
-1. Run `npm start` and open the game in a browser.
+1. Run `npm start` and open the game in a browser. You can also use
+   `npm run dev` to start the server with `DEBUG=1`.
 2. If the truck never moves or "Clock In" does nothing, open the browser's developer console (usually F12).
 3. With debug logging enabled (see step 5), look for messages like
    "Asset failed to load" or "init() did not execute."
    When an asset fails to load, a message now appears on the page reminding
-   you to start the game with `npm start`.
+   you to start the game with `npm start` (or `npm run dev`).
 4. If customers reach the counter but never order, check for
    `showDialog early exit` warnings. This usually means initialization
    failed and some UI elements were never created.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "preinstall": "node scripts/check-node-version.mjs",
     "start": "http-server -p 8080 -c-1",
+    "dev": "DEBUG=1 http-server -p 8080 -c-1",
     "pretest": "test -d node_modules || npm ci && npm run lint",
     "test": "node test/test.js",
     "test:unit": "SKIP_PUPPETEER=1 node test/test.js",


### PR DESCRIPTION
## Summary
- add `dev` npm script for debugging
- document dev script in Getting Started and Debugging sections

## Testing
- `npm test` *(fails: Parsing error in src/main.js)*
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_686953125d88832f9640193705f61108