### PR TITLE
Add queue logic tests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,16 +23,6 @@ import { initDialogAssets, fadeInButtons, blowButtonsAway, drawDialogBubble, res
 export let Assets, Scene, Customers, config;
 export let showStartScreenFn, handleActionFn, spawnCustomerFn, scheduleNextSpawnFn, showDialogFn, animateLoveChangeFn, blinkButtonFn;
 
-// Minimum duration when a customer dashes to the table
-const DART_MIN_DURATION = 300;
-// Maximum speed (pixels per second) when dashing to the table
-const DART_MAX_SPEED = (560 / 6) * 3;
-// Offset for the drink emoji when the customer holds it
-// Raise it slightly so it appears near their hands instead of their feet
-// Also determines where the drink lands when tossed to a customer
-// Lowered by 10px so the drink doesn't land on top of their head
-const DRINK_HOLD_OFFSET = { x: 0, y: -10 };
-
 const HEART_EMOJIS = {
   [CustomerState.NORMAL]: null,
   [CustomerState.BROKEN]: "💔",


### PR DESCRIPTION
## Summary
- add new unit tests for lureNextWanderer and moveQueueForward
- remove redundant constants from `main.js`
- supply extra stubs for handleAction test

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68695316d7d4832f9527294f6b748e92