### PR TITLE
Fix AudioContext warning

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -15,5 +15,10 @@ export const baseConfig = {
     width: 480,
     height: 640
   },
-  pixelArt: true
+  pixelArt: true,
+  audio: {
+    // Disable WebAudio to avoid creating an AudioContext when we don't
+    // use any sounds. This prevents browser autoplay warnings.
+    noAudio: true
+  }
 };


### PR DESCRIPTION
## Summary
- disable Phaser's audio features so browsers don't create an AudioContext

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68695d83376c832fb2267b1b980862fb