### PR TITLE
Fix TweenChain errors

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -5,7 +5,7 @@ import { ORDER_X, ORDER_Y } from './customers.js';
 import { DOG_COUNTER_RADIUS, animateDogPowerUp, PUP_CUP_TINT } from './entities/dog.js';
 import { receipt, emojiFor } from './assets.js';
 import { GameState } from './state.js';
-import { blinkButton, createGrayscaleTexture } from './ui/helpers.js';
+import { blinkButton, createGrayscaleTexture, playIfNotEmpty } from './ui/helpers.js';
 
 export const DART_MIN_DURATION = 300;
 export const DART_MAX_SPEED = (560 / 6) * 3;
@@ -119,7 +119,7 @@ function fadeInButtons(canSell){
       btnGive.glowTween = this.tweens.add({ targets: btnGive.glow, alpha: {from:0.1, to:0.05}, duration: dur(800), yoyo: true, repeat: -1 });
     }
   }, []);
-  timeline.play();
+  playIfNotEmpty(timeline);
 }
 
 function blowButtonsAway(except){
@@ -397,7 +397,7 @@ function showDialog(){
             if (btnRef.zone && btnRef.zone.input) btnRef.zone.input.enabled = true;
           }
         });
-        tl.play();
+        playIfNotEmpty(tl);
       };
       if(this.time && this.time.delayedCall){
         this.time.delayedCall(dur(250), showPrice, [], this);

--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -2,7 +2,7 @@ import { ORDER_X, ORDER_Y } from '../customers.js';
 import { GameState } from '../state.js';
 import { CustomerState } from '../constants.js';
 import { dur, scaleForY } from '../ui.js';
-import { setDepthFromBottom, createGlowTexture } from '../ui/helpers.js';
+import { setDepthFromBottom, createGlowTexture, playIfNotEmpty } from '../ui/helpers.js';
 import { scatterSparrows } from '../sparrow.js';
 
 export const DOG_MIN_Y = ORDER_Y + 20;
@@ -126,7 +126,7 @@ export function animateDogGrowth(scene, dog, cb) {
     arrow.destroy();
     if(cb) cb();
   }, []);
-  tl.play();
+  playIfNotEmpty(tl);
 }
 
 export function animateDogPowerUp(scene, dog, cb, finalTint = null){
@@ -223,7 +223,7 @@ export function animateDogPowerUp(scene, dog, cb, finalTint = null){
     scaleDog(dog);
     if(cb) cb();
   }, []);
-  tl.play();
+  playIfNotEmpty(tl);
 }
 
 // Keep the dog positioned near its owner and react to other customers.
@@ -338,7 +338,7 @@ export function updateDog(owner) {
       if (dog.anims && dog.play) {
         dog.play('dog_walk');
       }
-      tl.play();
+      playIfNotEmpty(tl);
       if (seenBird) scatterSparrows(this);
       return;
     }
@@ -587,7 +587,7 @@ export function dogTruckRuckus(scene, dog){
     }
   }, []);
   if (dog.anims && dog.play) { dog.play('dog_walk'); }
-  tl.play();
+  playIfNotEmpty(tl);
 }
 
 export function dogRefuseJumpBark(dog, scatter=true){

--- a/src/intro.js
+++ b/src/intro.js
@@ -5,7 +5,7 @@ import { GameState, resetAchievements } from './state.js';
 import { debugLog, DEBUG } from './debug.js';
 import { dur } from './ui.js';
 import { spawnSparrow, scatterSparrows } from './sparrow.js';
-import { createGrayscaleTexture, createGlowTexture } from './ui/helpers.js';
+import { createGrayscaleTexture, createGlowTexture, playIfNotEmpty } from './ui/helpers.js';
 
 let startOverlay = null;
 let startButton = null;
@@ -198,7 +198,7 @@ function playOpening(scene){
       alpha: 0,
       duration: 200
     });
-    tl.play();
+    playIfNotEmpty(tl);
   };
 
   let thrustEvent = null;
@@ -240,7 +240,7 @@ function playOpening(scene){
       }
     }
   });
-  tl.play();
+  playIfNotEmpty(tl);
 }
 
 function showStartScreen(scene){
@@ -887,7 +887,7 @@ function showStartScreen(scene){
     if (fadeTargets.length) {
       tl.add({targets:fadeTargets,alpha:0,duration:600});
     }
-    tl.play();
+    playIfNotEmpty(tl);
   });
 
 }
@@ -1048,7 +1048,7 @@ function playIntro(scene){
       hopOut();
     }
   });
-  intro.play();
+  playIfNotEmpty(intro);
 }
 
 export { playOpening, showStartScreen, playIntro, hideStartMessages, hideStartScreen };

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ import { scheduleSparrowSpawn, updateSparrows, cleanupSparrows, scatterSparrows 
 import { DOG_TYPES, DOG_MIN_Y, DOG_COUNTER_RADIUS, sendDogOffscreen, scaleDog, cleanupDogs, updateDog, dogTruckRuckus, dogRefuseJumpBark, dogBarkAt, animateDogPowerUp, barkProps, PUP_CUP_TINT } from './entities/dog.js';
 import { startWander } from './entities/wanderers.js';
 
-import { flashBorder, flashFill, blinkButton, applyRandomSkew, setDepthFromBottom, createGrayscaleTexture, createGlowTexture, createHpBar } from './ui/helpers.js';
+import { flashBorder, flashFill, blinkButton, applyRandomSkew, setDepthFromBottom, createGrayscaleTexture, createGlowTexture, createHpBar, playIfNotEmpty } from './ui/helpers.js';
 
 import { animateStatChange, updateCloudStatus, updateMoneyDisplay, countPrice, cleanupFloatingEmojis } from "./hud.js";
 import { restartGame } from "./endings.js";
@@ -255,7 +255,7 @@ export function setupGame(){
         });
       }
     }, []);
-    timeline.play();
+    playIfNotEmpty(timeline);
   }
 
 
@@ -1281,7 +1281,7 @@ let sideCAlpha=0;
               if (btnRef.zone && btnRef.zone.input) btnRef.zone.input.enabled = true;
             }
           });
-          tl.play();
+          playIfNotEmpty(tl);
         };
         if(this.time && this.time.delayedCall){
           this.time.delayedCall(dur(250), showPrice, [], this);
@@ -1382,7 +1382,7 @@ let sideCAlpha=0;
           tl.setCallback('onComplete', () => {
             animateDogPowerUp(this, target, react, PUP_CUP_TINT);
           }, []);
-          tl.play();
+          playIfNotEmpty(tl);
         } else if (this.time) {
           this.time.delayedCall(dur(100), react, [], this);
         } else {
@@ -2104,7 +2104,7 @@ let sideCAlpha=0;
           scale: 0,
           duration: dur(400)
         });
-        tl.play();
+        playIfNotEmpty(tl);
       },[],this);
         } else if(type==='give'){
       const ticket=dialogPriceContainer;
@@ -2164,7 +2164,7 @@ let sideCAlpha=0;
             lossStamp.setVisible(false);
             lossStamp.setAlpha(1);
           });
-          flick.play();
+          playIfNotEmpty(flick);
         }, [], this);
         // Ticket turns grayscale while the price flashes red
         if(dialogPriceTicket){
@@ -2282,7 +2282,7 @@ let sideCAlpha=0;
               }
             }
           });
-          tl.play();
+          playIfNotEmpty(tl);
         },[],this);
       }
 } else if(type!=='refuse'){
@@ -2346,7 +2346,7 @@ let sideCAlpha=0;
       const endDelay = showTip ? 0 : dur(300);
       tl.add({targets:moving,x:destX,y:destY,scale:0,alpha:0,duration:dur(400),delay:endDelay});
 
-      tl.play();
+      playIfNotEmpty(tl);
     }
 
     // Reaction happens after the order animation completes
@@ -2417,7 +2417,7 @@ let sideCAlpha=0;
                 popOne(idx+1);
               }
         }});
-        tl.play();
+        playIfNotEmpty(tl);
       }, [], this);
     };
 
@@ -2637,7 +2637,7 @@ let sideCAlpha=0;
             tl.add({targets:c.sprite,x:Phaser.Math.Between(40,440),y:Phaser.Math.Between(WANDER_TOP,WANDER_BOTTOM),duration:dur(Phaser.Math.Between(300,500)),ease:'Sine.easeInOut'});
           }
           tl.add({targets:c.sprite,x:targetX,duration:dur(WALK_OFF_BASE/1.2),onStart:()=>{if(c.dog){scene.tweens.killTweensOf(c.dog);if(c.dog.followEvent)c.dog.followEvent.remove(false);}},onComplete:()=>{c.sprite.destroy();remaining--;if(remaining===0&&done)done();}});
-          tl.play();
+          playIfNotEmpty(tl);
           if(c.dog){
             const dog=c.dog;
             if(!dog) { return; }
@@ -2663,7 +2663,7 @@ let sideCAlpha=0;
             }, []);
             dTl.setCallback('onComplete',()=>{ if(dog) dog.setFrame(1); }, []);
             if(dog && dog.anims && dog.play){ dog.play('dog_walk'); }
-            dTl.play();
+            playIfNotEmpty(dTl);
           }
           return;
         }
@@ -2755,7 +2755,7 @@ function dogsBarkAtFalcon(){
           }
         }, []);
         if(dog.anims && dog.play){ dog.play('dog_walk'); }
-        dTl.play();
+        playIfNotEmpty(dTl);
       });
     }
 
@@ -3014,7 +3014,7 @@ function dogsBarkAtFalcon(){
                   tl.add({targets:dog,angle:-10,duration:dur(80)});
                   tl.add({targets:dog,angle:10,duration:dur(80)});
                   tl.add({targets:dog,angle:0,duration:dur(80),onComplete:()=>{ ensureOnGround(dog); dog.attacking=false; }});
-                  tl.play();
+                  playIfNotEmpty(tl);
                 }
               });
             }
@@ -3053,7 +3053,7 @@ function dogsBarkAtFalcon(){
                   tl.add({targets:dog,angle:-10,duration:dur(80)});
                   tl.add({targets:dog,angle:10,duration:dur(80)});
                   tl.add({targets:dog,angle:0,duration:dur(80),onComplete:()=>{ ensureOnGround(dog); if(done) done(); }});
-                  tl.play();
+                  playIfNotEmpty(tl);
                 }
               });
             }
@@ -3379,7 +3379,7 @@ function dogsBarkAtFalcon(){
               attackOnce();
             }
           }, []);
-          tl.play();
+          playIfNotEmpty(tl);
         }});
       }});
     };

--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -158,4 +158,13 @@ export function createHpBar(scene, width=40, height=6, maxHp=10){
   return container;
 }
 
+export function playIfNotEmpty(tl){
+  if(!tl || typeof tl.play!=="function") return;
+  if((Array.isArray(tl.data) && tl.data.length>0) || tl.totalData>0){
+    tl.play();
+  } else if(typeof console!=='undefined' && console.warn){
+    console.warn('Attempted to play empty TweenChain');
+  }
+}
+
 export { blinkButton as default };


### PR DESCRIPTION
## Summary
- avoid playing tween chains if they have no tweens
- add helper `playIfNotEmpty` and use it throughout the codebase

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869610efc48832fab2fbf984929b335