### PR TITLE
Fix Phaser tween chain init

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -98,7 +98,7 @@ function fadeInButtons(canSell){
   }
   resetBtn(btnGive, FINAL.give);
   resetBtn(btnRef, FINAL.ref);
-  const timeline = this.tweens.chain({paused:true});
+  const timeline = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
   if(canSell){
     timeline.add({ targets: btnSell, y: BUTTON_Y, angle: 0, alpha: 1, ease: 'Sine.easeOut', duration: dur(250) });
   }
@@ -377,7 +377,7 @@ function showDialog(){
         const behindDepth = truck && truck.depth ? truck.depth - 1 : frontDepth - 1;
         dialogPriceContainer.setDepth(behindDepth);
         const midY = truck ? truck.y - (truck.displayHeight||0)/2 - 40 : priceTargetY - 40;
-        const tl = this.tweens.chain({paused:true});
+        const tl = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
         tl.add({ targets: dialogPriceContainer, y: peekY, scale: 0.3, duration: dur(100), ease: 'Sine.easeOut' });
         tl.add({ targets: dialogPriceContainer, x: priceTargetX, y: midY, scale: 0.5, duration: dur(250), ease: 'Sine.easeOut' });
         tl.add({ targets: dialogPriceContainer, x: priceTargetX, y: priceTargetY, scale: 0.8, duration: dur(250), ease: 'Sine.easeOut', onStart: ()=> dialogPriceContainer.setDepth(frontDepth) });

--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -88,7 +88,7 @@ export function animateDogGrowth(scene, dog, cb) {
   const dir = dog.dir || 1;
   const baseX = scaleForY(dog.y) * finalFactor * dir;
   const baseY = scaleForY(dog.y) * finalFactor;
-  const tl = scene.tweens.chain({paused:true});
+  const tl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
   const growX = baseX * 1.2;
   const growY = baseY * 1.2;
   // show an up arrow while the dog grows
@@ -157,7 +157,7 @@ export function animateDogPowerUp(scene, dog, cb, finalTint = null){
     onComplete: () => sparkle.destroy()
   });
 
-  const tl = scene.tweens.chain({paused:true});
+  const tl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
   const originalTint = dog.tintTopLeft || 0xffffff;
   const shiftHue = (color, amount) => {
     const rgb = Phaser.Display.Color.IntegerToRGB(color);
@@ -308,7 +308,7 @@ export function updateDog(owner) {
         duration: dur(600),
         onComplete: () => bark.destroy()
       });
-      const tl = this.tweens.chain({paused:true});
+      const tl = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
       tl.add({ targets: dog, y: '-=15', duration: dur(100), yoyo: true, repeat: 1 });
       tl.add({ targets: dog, x: s.x, y: s.y, duration: dur(300) });
       tl.add({ targets: dog, x: '-=12', duration: dur(120), yoyo: true, repeat: 1 });
@@ -566,7 +566,7 @@ export function dogTruckRuckus(scene, dog){
   scene.tweens.killTweensOf(dog);
   const truck = GameState.truck;
   if(!truck) return;
-  const tl = scene.tweens.chain({paused:true});
+  const tl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
   const left = truck.x - truck.displayWidth/2 + 20 * truck.scaleX;
   const right = truck.x + truck.displayWidth/2 - 20 * truck.scaleX;
   const top = truck.y - truck.displayHeight/2;

--- a/src/intro.js
+++ b/src/intro.js
@@ -115,7 +115,7 @@ function playOpening(scene){
     .setScale(2.6)
     .setAngle(-45);
 
-  const tl = scene.tweens.chain({paused:true,callbackScope:scene,onComplete:()=>{
+  const tl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:scene,onComplete:()=>{
     if (startWhite) { startWhite.destroy(); startWhite = null; }
   }});
 
@@ -181,7 +181,7 @@ function playOpening(scene){
 
     const targetX = cup.x + Math.cos(ang) * dist;
     const targetY = cup.y + Math.sin(ang) * dist + 30;
-    const tl = scene.tweens.chain({paused:true,
+    const tl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],
       callbackScope: scene,
       onComplete: () => cup.destroy()
     });
@@ -852,7 +852,7 @@ function showStartScreen(scene){
     for(let i=0;i<2;i++){
       spawnSparrow(scene,{ground:true});
     }
-    const tl=scene.tweens.chain({paused:true,callbackScope:scene,onComplete:()=>{
+    const tl=scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:scene,onComplete:()=>{
       if (window.hideMiniGame) window.hideMiniGame();
       if(startButton) startButton.destroy();
       if(startOverlay){startOverlay.destroy(); startOverlay=null;}
@@ -988,7 +988,7 @@ function playIntro(scene){
     });
     scene.time.delayedCall(dur(1300), () => smokeEvent.remove(), [], scene);
   }
-  const intro=scene.tweens.chain({paused:true,callbackScope:scene});
+  const intro=scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:scene});
   const hopOut=()=>{
     const startX = GameState.truck.x + GameState.truck.displayWidth / 2 - 20;
     const startY = GameState.truck.y - 10;

--- a/src/main.js
+++ b/src/main.js
@@ -202,7 +202,7 @@ export function setupGame(){
     resetBtn(btnGive, FINAL.give);
     resetBtn(btnRef, FINAL.ref);
 
-    const timeline = this.tweens.chain({paused:true});
+    const timeline = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
     if(canSell){
       timeline.add({
         targets: btnSell,
@@ -1240,7 +1240,7 @@ let sideCAlpha=0;
           const midY = truckRef ?
             truckRef.y - (truckRef.displayHeight||0)/2 - 40 :
             priceTargetY - 40;
-          const tl = this.tweens.chain({paused:true});
+          const tl = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
           tl.add({
             targets: dialogPriceContainer,
             y: peekY,
@@ -1376,7 +1376,7 @@ let sideCAlpha=0;
         };
         if(target.isDog && type==='give'){
           // shrink the treat into the dog before the power up
-          const tl = this.tweens.chain({paused:true});
+          const tl = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
           tl.add({ targets: dialogDrinkEmoji, scale: 0, duration: dur(150), ease:'Cubic.easeIn' });
           tl.add({ targets: dialogDrinkEmoji, alpha:0, duration: dur(80) });
           tl.setCallback('onComplete', () => {
@@ -2062,7 +2062,7 @@ let sideCAlpha=0;
       this.time.delayedCall(delay,()=>{
         paidStamp.setVisible(false);
         tipText.setVisible(false);
-        const tl=this.tweens.chain({paused:true,callbackScope:this,onComplete:()=>{
+        const tl=this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:this,onComplete:()=>{
             stopSellGlowSparkle.call(this, () => {
               clearDialog.call(this);
               ticket.setVisible(false);
@@ -2157,7 +2157,7 @@ let sideCAlpha=0;
           .setVisible(true);
         skewFn2(lossStamp);
         this.time.delayedCall(dur(500), () => {
-          const flick = this.tweens.chain({paused:true});
+          const flick = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
           flick.add({ targets: lossStamp, alpha: 0.5, duration: dur(60), yoyo: true, repeat: 2 });
           flick.add({ targets: lossStamp, alpha: 0, duration: dur(300) });
           flick.setCallback('onComplete', () => {
@@ -2222,7 +2222,7 @@ let sideCAlpha=0;
           if(this.tweens){
             this.tweens.add({targets:ticket,x:'+=6',duration:dur(60),yoyo:true,repeat:2});
           }
-          const tl=this.tweens.chain({paused:true,callbackScope:this,onComplete:()=>{
+          const tl=this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:this,onComplete:()=>{
               clearDialog.call(this);
               ticket.setVisible(false);
               updateMoney(mD);
@@ -2307,7 +2307,7 @@ let sideCAlpha=0;
       const destX=moneyText.x;
       const destY=moneyText.y;
       const moving=[reportLine1];
-      const tl=this.tweens.chain({paused:true,callbackScope:this,onComplete:()=>{
+      const tl=this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:this,onComplete:()=>{
           reportLine1.setVisible(false).alpha=1;
           reportLine2.setVisible(false).alpha=1;
           reportLine3.setVisible(false).alpha=1;
@@ -2379,7 +2379,7 @@ let sideCAlpha=0;
           .setOrigin(0.5).setDepth(10);
       }
       this.time.delayedCall(dur(delay), () => {
-        const tl = this.tweens.chain({paused:true,callbackScope:this});
+        const tl = this.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:this});
         // spin the face into a heart (or keep the upset face)
         tl.add({
           targets:h,
@@ -2632,7 +2632,7 @@ let sideCAlpha=0;
         }
 
         if(state===CustomerState.NORMAL){
-          const tl=scene.tweens.chain({paused:true});
+          const tl=scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
           for(let i=0;i<5;i++){
             tl.add({targets:c.sprite,x:Phaser.Math.Between(40,440),y:Phaser.Math.Between(WANDER_TOP,WANDER_BOTTOM),duration:dur(Phaser.Math.Between(300,500)),ease:'Sine.easeInOut'});
           }
@@ -2645,7 +2645,7 @@ let sideCAlpha=0;
             const { scale, rise } = barkProps(dog);
             const bark=scene.add.sprite(dog.x,dog.y-20,'dog1',3).setOrigin(0.5).setDepth(dog.depth+1).setScale(Math.abs(dog.scaleX)*scale,Math.abs(dog.scaleY)*scale);
             scene.tweens.add({targets:bark,y:`-=${rise}`,alpha:0,duration:dur(600),onComplete:()=>bark.destroy()});
-            const dTl=scene.tweens.chain({paused:true});
+            const dTl=scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
             for(let j=0;j<4;j++){
               const ang=Phaser.Math.FloatBetween(0,Math.PI*2);
               const r=Phaser.Math.Between(40,60);
@@ -2722,7 +2722,7 @@ function dogsBarkAtFalcon(){
         const dir = dog.x < falcon.x ? 1 : -1;
         const attackX = falcon.x - dir * 40;
         const attackY = Math.max(DOG_MIN_Y, falcon.y + 10);
-        const dTl = scene.tweens.chain({paused:true});
+        const dTl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
         dTl.add({
           targets: dog,
           x: attackX,
@@ -3008,7 +3008,7 @@ function dogsBarkAtFalcon(){
                 yoyo:true,
                 ease:'Sine.easeOut',
                 onComplete:()=>{
-                  const tl=scene.tweens.chain({paused:true});
+                  const tl=scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
                   tl.add({targets:dog,angle:-15,duration:dur(80)});
                   tl.add({targets:dog,angle:15,duration:dur(80)});
                   tl.add({targets:dog,angle:-10,duration:dur(80)});
@@ -3047,7 +3047,7 @@ function dogsBarkAtFalcon(){
                 yoyo: true,
                 ease: 'Sine.easeOut',
                 onComplete: () => {
-                  const tl = scene.tweens.chain({paused:true});
+                  const tl = scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}]});
                   tl.add({targets:dog,angle:-15,duration:dur(80)});
                   tl.add({targets:dog,angle:15,duration:dur(80)});
                   tl.add({targets:dog,angle:-10,duration:dur(80)});
@@ -3353,7 +3353,7 @@ function dogsBarkAtFalcon(){
             GameState.girlHP=Math.max(0,GameState.girlHP-1);
             girlHpBar.setHp(GameState.girlHP);
             coffeeExplosion(scene);
-            const tl=scene.tweens.chain({paused:true,callbackScope:scene});
+            const tl=scene.tweens.chain({paused:true,tweens:[{targets:{},duration:0}],callbackScope:scene});
           tl.add({targets:falcon,y:targetY+10,duration:dur(80),yoyo:true});
           tl.add({targets:girl,y:girl.y+5,duration:dur(80),yoyo:true,
                    onStart:()=>sprinkleBursts(scene),


### PR DESCRIPTION
## Summary
- patch all `tweens.chain` calls to include a dummy tween
- avoid `setActiveState` error under Phaser 3.90

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686964c5fb30832f8a846248e06c19dc