### PR TITLE
Fix leftover falcon after win and improve landing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4127,7 +4127,18 @@ function dogsBarkAtFalcon(){
       .setDepth(20);
     falcon.anims.play('falcon_fly');
     GameState.falcon = falcon;
-    this.tweens.add({targets:falcon,y:truck.y-(truck.displayHeight||0)/2-10,duration:dur(800),ease:'Sine.easeIn',onComplete:()=>{falcon.anims.stop();showHighMoneyLoss.call(this);}});
+    const landingY = truck.y - (truck.displayHeight || 0)/2 + 5;
+    this.tweens.add({
+      targets: falcon,
+      y: landingY,
+      duration: dur(800),
+      ease: 'Sine.easeIn',
+      onComplete: () => {
+        falcon.anims.stop();
+        this.tweens.add({targets:truck,x:truck.x+8,duration:dur(80),yoyo:true,repeat:3});
+        this.time.delayedCall(dur(1000),()=>{showHighMoneyLoss.call(this);});
+      }
+    });
   }
 
   function startLoveSequence(){
@@ -4241,6 +4252,10 @@ function dogsBarkAtFalcon(){
     scene.tweens.killAll();
     scene.time.removeAllEvents();
     cleanupFloatingEmojis();
+    if(GameState.falcon){
+      GameState.falcon.destroy();
+      GameState.falcon = null;
+    }
     cleanupHeartEmojis(scene);
     cleanupBarks();
     cleanupBursts();


### PR DESCRIPTION
## Summary
- animate Lady Falcon landing lower before the "fired" ending
- shake the truck and delay the ending screen
- destroy falcon sprite at start of high money loss sequence to prevent leftovers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869fc89affc832f93f24320f352bcf7