### PR TITLE
Fix money display and sparrow target

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,10 @@ const DART_MAX_SPEED = (560 / 6) * 3;
 // Lowered by 10px so the drink doesn't land on top of their head
 const DRINK_HOLD_OFFSET = { x: 0, y: -10 };
 
+// Offset for the dollar sign relative to the money value
+// Moves slightly right and up so it sits closer to the number
+const MONEY_DOLLAR_OFFSET = { x: 2, y: -2 };
+
 // Cloud display positions
 // When money reaches $200 the dollar cloud sits at the top value.
 // Hearts use a similar scale based on the MAX_L constant.
@@ -185,8 +189,8 @@ export function setupGame(){
       moneyText.setPosition(centerX, centerY);
       if(moneyDollar){
         moneyDollar.setPosition(
-          centerX - moneyText.displayWidth/2 - moneyDollar.displayWidth/2,
-          centerY
+          centerX - moneyText.displayWidth/2 - moneyDollar.displayWidth/2 + MONEY_DOLLAR_OFFSET.x,
+          centerY + MONEY_DOLLAR_OFFSET.y
         );
       }
     }

--- a/src/sparrow.js
+++ b/src/sparrow.js
@@ -20,38 +20,23 @@ export function sparrowSpawnDelay(love) {
 
 function randomTarget(scene){
   const { width } = scene.scale;
-  const options = [
-    // ground near the middle
-    new Phaser.Math.Vector2(
-      Phaser.Math.Between(180,300),
-      Phaser.Math.Between(260,300)
-    ),
-    // top of the truck
-    (() => {
-      const truck = GameState.truck;
-      const moving = truck && scene.tweens && scene.tweens.isTweening && scene.tweens.isTweening(truck);
-      if (truck && !moving && truck.getTopCenter) {
-        const top = truck.getTopCenter();
-        const y = top.y + 25 * truck.scaleY;
-        const left = truck.x - truck.displayWidth / 2 + 40 * truck.scaleX;
-        const right = truck.x + truck.displayWidth / 2 - 33 * truck.scaleX;
-        return new Phaser.Math.Vector2(
-          Phaser.Math.Between(left, right),
-          y
-        );
-      }
-      return new Phaser.Math.Vector2(
-        Phaser.Math.Between(220, 260),
-        217
-      );
-    })(),
-    // offscreen above
-    new Phaser.Math.Vector2(
-      Phaser.Math.Between(-40,width+40),
-      -40
-    )
-  ];
-  return Phaser.Utils.Array.GetRandom(options);
+  const truck = GameState.truck;
+  const moving = truck && scene.tweens && scene.tweens.isTweening && scene.tweens.isTweening(truck);
+  if (truck && !moving && truck.getTopCenter) {
+    const top = truck.getTopCenter();
+    const y = top.y + 25 * truck.scaleY;
+    const left = truck.x - truck.displayWidth / 2 + 40 * truck.scaleX;
+    const right = truck.x + truck.displayWidth / 2 - 33 * truck.scaleX;
+    return new Phaser.Math.Vector2(
+      Phaser.Math.Between(left, right),
+      y
+    );
+  }
+  // offscreen above
+  return new Phaser.Math.Vector2(
+    Phaser.Math.Between(-40, width + 40),
+    -40
+  );
 }
 
 export class Sparrow {


### PR DESCRIPTION
## Summary
- adjust dollar sign position relative to the cloud number
- restrict sparrows to land only on the truck

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869fe974a08832f82b4a2bd8c986f0e