### PR TITLE
Fix cup burst fade timing

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -167,7 +167,8 @@ function playOpening(scene){
     tl.add({
       targets: cup,
       alpha: 0,
-      duration: dur(600)
+      duration: dur(600),
+      offset: '-=600'
     });
     tl.play();
   };


### PR DESCRIPTION
## Summary
- fade each coffee cup sprite while moving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a0a4cec98832f8bf6e3bf875a0f9b