### PR TITLE
Fix achievements fade on first start

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -554,9 +554,7 @@ function showStartScreen(scene, opts = {}){
     }
     phoneContainer.add(container);
     badgeIcons.push(container);
-    if(!revealNew || !delayExtras){
-      extraObjects.push({ obj: container, alpha: container.alpha });
-    }
+    extraObjects.push({ obj: container, alpha: container.alpha });
     container.setAlpha(0);
   });
 


### PR DESCRIPTION
## Summary
- always queue earned achievement icons for fade-in

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a0dbe85a0832f8e0dc0ad5ab04333