### PR TITLE
Update truck and intro animations

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -1101,13 +1101,16 @@ function playIntro(scene){
       t:1,
       duration:dur(700),
       ease:'Sine.easeInOut',
-      onStart:()=>GameState.girl.setVisible(true),
+      onStart:()=>{ GameState.girl.setVisible(true); GameState.girl.setAngle(0); },
       onUpdate:()=>{
         curve.getPoint(follower.t,follower.vec);
         GameState.girl.setPosition(follower.vec.x,follower.vec.y);
+        const angle = Math.sin(follower.t * Math.PI) * 20;
+        GameState.girl.setAngle(angle);
       },
       onComplete:()=>{
         GameState.girl.setPosition(endX,endY);
+        GameState.girl.setAngle(0);
         scene.tweens.add({
           targets:GameState.girl,
           y:endY-10,

--- a/src/main.js
+++ b/src/main.js
@@ -1428,9 +1428,14 @@ export function setupGame(){
                 .setPosition(startX, startY)
                 .setScale(0.2);
               if (truckRef) {
+                const targetScaleX = truckRef.scaleX * 0.96;
+                const targetScaleY = truckRef.scaleY * 0.96;
                 this.tweens.add({
                   targets: truckRef,
-                  angle: 10,
+                  angle: 6,
+                  y: "+=6",
+                  scaleX: targetScaleX,
+                  scaleY: targetScaleY,
                   duration: dur(150),
                   yoyo: true,
                   hold: dur(100),


### PR DESCRIPTION
## Summary
- tweak truck ducking effect when showing the price ticket
- rotate Coffee Girl during her intro hop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a12e1bc2c832f8560b834e94a77f3