### PR TITLE
Add true love victory messages

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -907,11 +907,18 @@ function showStartScreen(scene, opts = {}){
       ['remember ur value!', "don't let them take it all", 'get that job back or bounce', 'gen z would revolt']
     ];
 
+    const loveMsgs=[
+      ['everyone stan coffee girl ❤️', 'u two r goals 💑', 'literally hearts everywhere 💕'],
+      ['park gossip is all love story vibes', 'ur crush got the whole crowd cheering', 'love > money fr 😍'],
+      ['coffee tastes sweeter when ur in love ☕💖', 'they keep asking about the wedding lol', 'ur otp is trending']
+    ];
+
     msgOptions = defaultMsgs;
     if(GameState.lastEndKey === 'falcon_end') msgOptions = falconMsgs;
     else if(GameState.lastEndKey === 'falcon_victory' || GameState.lastEndKey === 'muse_victory') msgOptions = victoryMsgs;
     else if(GameState.lastEndKey === 'revolt_end') msgOptions = revoltMsgs;
     else if(GameState.lastEndKey === 'fired_end') msgOptions = firedMsgs;
+    else if(GameState.lastEndKey === 'true_love') msgOptions = loveMsgs;
 
     // scheduleStartMessages() handles message timing after the intro fades
   }

--- a/src/main.js
+++ b/src/main.js
@@ -4118,6 +4118,8 @@ function dogsBarkAtFalcon(){
       .setOrigin(0.5,1)
       .setScale(1.5)
       .setDepth(20);
+    awardBadge(this, spriteKey);
+    GameState.lastEndKey = 'true_love';
     const bigGirl = this.add.image(240,320,'girl')
       .setOrigin(0.5,1)
       .setScale(1.5)


### PR DESCRIPTION
## Summary
- award a badge when the true love ending occurs and record it as `true_love`
- show new Gen Z style text messages after winning with true love

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a14c71e04832fa3a175cc4ad79b3b