### PR TITLE
Add Fired ending music and song icons

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -91,6 +91,8 @@ export function preload(){
   loader.spritesheet('lady_falcon','assets/lady_falcon.png',{frameWidth:64,frameHeight:64});
   loader.image('falcon_end','assets/ladyfalconend.png');
   loader.image('fired_end','assets/firedend.png');
+  loader.audio('fired_intro',"assets/music/you're_fired_intro.mp3");
+  loader.audio('fired_loop',"assets/music/you're_fired_loop.mp3");
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('muse_victory','assets/musevictory.png');

--- a/src/intro.js
+++ b/src/intro.js
@@ -6,6 +6,7 @@ import { debugLog, DEBUG } from './debug.js';
 import { dur } from './ui.js';
 import { spawnSparrow, scatterSparrows } from './sparrow.js';
 import { createGrayscaleTexture, createGlowTexture } from './ui/helpers.js';
+import { playSong, stopSong } from './music.js';
 
 let startOverlay = null;
 let startButton = null;
@@ -54,6 +55,18 @@ function hideStartScreen(){
   if(cupShadow) cupShadow.setVisible(false);
   if(classicButton) classicButton.setVisible(false);
   if(resetButton) resetButton.setVisible(false);
+}
+
+function updateSongIcons(scene){
+  scene = scene || this;
+  badgeIcons.forEach((container, idx) => {
+    const key = ALL_BADGES[idx];
+    if (!container || !container.list || !container.list[0]) return;
+    const img = container.list[0];
+    const grayKey = `${key}_gray`;
+    if (!scene.textures.exists(grayKey)) createGrayscaleTexture(scene, key, grayKey);
+    img.setTexture(GameState.currentSong === key ? key : grayKey);
+  });
 }
 
 function playOpening(scene){
@@ -548,6 +561,12 @@ function showStartScreen(scene, opts = {}){
       children.unshift(glow);
     }
     const container = scene.add.container(slot.x,slot.y,children).setDepth(16);
+    container.setSize(slotSize, slotSize);
+    container.setInteractive({ useHandCursor: true });
+    container.on('pointerdown', () => {
+      playSong(scene, key);
+      updateSongIcons(scene);
+    });
     if(GameState.badgeCounts[key] > 1){
       const txt = scene.add.text(0,0,String(GameState.badgeCounts[key]),{font:'16px sans-serif',fill:'#fff'}).setOrigin(0.5);
       container.add(txt);
@@ -577,10 +596,12 @@ function showStartScreen(scene, opts = {}){
       }
     }
     phoneContainer.add(container);
-    badgeIcons.push(container);
-    extraObjects.push({ obj: container, alpha: container.alpha });
-    container.setAlpha(0);
+  badgeIcons.push(container);
+  extraObjects.push({ obj: container, alpha: container.alpha });
+  container.setAlpha(0);
   });
+
+  updateSongIcons(scene);
 
   if(revealNew){
     GameState.achievementsRevealed = true;
@@ -1160,9 +1181,10 @@ function playIntro(scene){
   intro.play();
 }
 
-export { playOpening, showStartScreen, playIntro, hideStartMessages, hideStartScreen };
+export { playOpening, showStartScreen, playIntro, hideStartMessages, hideStartScreen, updateSongIcons };
 
 if (typeof window !== 'undefined') {
   window.hideStartMessages = hideStartMessages;
   window.hideStartScreen = hideStartScreen;
+  window.updateSongIcons = updateSongIcons;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import { flashBorder, flashFill, blinkButton, applyRandomSkew, setDepthFromBotto
 
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { playOpening, showStartScreen, playIntro } from './intro.js';
+import { playSong } from './music.js';
 import DesaturatePipeline from './desaturatePipeline.js';
 
 export let Assets, Scene, Customers, config;
@@ -4395,6 +4396,7 @@ function dogsBarkAtFalcon(){
 
   function showHighMoneyLoss(){
     const scene = this;
+    playSong(scene, 'fired_end');
     scene.tweens.killAll();
     scene.time.removeAllEvents();
     cleanupFloatingEmojis();

--- a/src/music.js
+++ b/src/music.js
@@ -1,0 +1,33 @@
+import { GameState } from './state.js';
+
+export function stopSong() {
+  if (GameState.songInstance && GameState.songInstance.stop) {
+    GameState.songInstance.stop();
+  }
+  GameState.songInstance = null;
+  GameState.currentSong = null;
+}
+
+export function playSong(scene, key) {
+  if (!scene || !scene.sound) return;
+  if (GameState.songInstance && GameState.songInstance.stop) {
+    GameState.songInstance.stop();
+  }
+  GameState.currentSong = key;
+  let intro;
+  let loop;
+  if (key === 'fired_end') {
+    intro = scene.sound.add('fired_intro');
+    loop = scene.sound.add('fired_loop', { loop: true });
+    GameState.songInstance = intro;
+    intro.once('complete', () => {
+      if (GameState.songInstance === intro) {
+        GameState.songInstance = loop;
+        loop.play();
+      }
+    });
+    intro.play();
+  } else {
+    GameState.songInstance = null;
+  }
+}

--- a/src/state.js
+++ b/src/state.js
@@ -42,6 +42,8 @@ export const GameState = {
   ,achievementsRevealed: false
   ,firedSeqStarted: false
   ,loveSeqStarted: false
+  ,currentSong: null
+  ,songInstance: null
 };
 
 export const floatingEmojis = [];


### PR DESCRIPTION
## Summary
- load new Fired intro and loop music assets
- track current song in `GameState`
- implement `music.js` helper to play/stop songs
- play Fired song during the fired ending sequence
- turn achievement icons into song selectors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ae18a2688832f83760b654e3e2a69