### PR TITLE
Fix persistent end screen portrait on phone screen

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -221,6 +221,12 @@ function showStartScreen(scene, opts = {}){
   scene = scene || this;
   const delayExtras = !!opts.delayExtras;
   if (typeof debugLog === 'function') debugLog('showStartScreen called');
+  if (GameState.carryPortrait) {
+    if (GameState.carryPortrait.scene) {
+      GameState.carryPortrait.destroy();
+    }
+    GameState.carryPortrait = null;
+  }
   // `cupShadow` is destroyed when the phone container is removed but the
   // variable persists between runs. If we try to re-add the old destroyed
   // object, Phaser throws a "Cannot read properties of undefined" error when


### PR DESCRIPTION
## Summary
- clear any leftover `carryPortrait` sprite when showing the start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b24d126d8832f88e214b863e38152