### PR TITLE
Fix particle and emoji timing

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -20,7 +20,6 @@ let openingDog = null;
 let badgeIcons = [];
 let iconSlots = [];
 let miniGameCup = null;
-let cupShadow = null;
 let classicButton = null;
 let resetButton = null;
 let phoneMask = null;
@@ -52,7 +51,6 @@ function hideStartScreen(){
   hideStartMessages();
   badgeIcons.forEach(b => b.setVisible(false));
   if(miniGameCup) miniGameCup.setVisible(false);
-  if(cupShadow) cupShadow.setVisible(false);
   if(classicButton) classicButton.setVisible(false);
   if(resetButton) resetButton.setVisible(false);
 }
@@ -227,14 +225,6 @@ function showStartScreen(scene, opts = {}){
     }
     GameState.carryPortrait = null;
   }
-  // `cupShadow` is destroyed when the phone container is removed but the
-  // variable persists between runs. If we try to re-add the old destroyed
-  // object, Phaser throws a "Cannot read properties of undefined" error when
-  // it attempts to access `sys` on the dead game object. Guard against this by
-  // clearing any lingering reference before creating the new start screen.
-  if (cupShadow && !cupShadow.scene) {
-    cupShadow = null;
-  }
   if (miniGameCup && !miniGameCup.scene) {
     miniGameCup = null;
   }
@@ -399,31 +389,7 @@ function showStartScreen(scene, opts = {}){
   }
   miniGameCup.setAlpha(0);
   extraObjects.push({ obj: miniGameCup, alpha: allEarned ? 1 : 0 });
-  if(!cupShadow){
-    const grayKey = 'coffeecup2_gray';
-    if(!scene.textures.exists(grayKey)) {
-      createGrayscaleTexture(scene, 'coffeecup2', grayKey);
-    }
-    cupShadow = scene.add
-        .image(cupSlot.x, cupSlot.y, grayKey)
-        .setDepth(16)
-        .setAlpha(0);
-    const tex = scene.textures.get(grayKey);
-    if (tex && tex.getSourceImage) {
-      const src = tex.getSourceImage();
-      const cupScale = (src && src.width && src.height)
-        ? slotSize / Math.max(src.width, src.height)
-        : 1;
-      cupShadow.setScale(cupScale);
-    }
-  } else {
-    cupShadow.setPosition(cupSlot.x, cupSlot.y);
-    cupShadow.setAlpha(0);
-  }
-  phoneContainer.add(cupShadow);
-  if(!allEarned){
-    extraObjects.push({ obj: cupShadow, alpha: 0.3 });
-  }
+  // Removed grayscale shadow behind the mini game cup
   // cupSlot is just a plain coordinate object, so calling setVisible
   // on it causes errors. Visibility is controlled by the cup and
   // shadow sprites instead.

--- a/src/main.js
+++ b/src/main.js
@@ -2010,7 +2010,7 @@ export function setupGame(){
         this.tweens.add({
           targets: sprite,
           x: waitX,
-          duration: dur(300),
+          duration: dur(600),
           onUpdate: (tw, t) => {
             if (current.heartEmoji && current.heartEmoji.scene && current.heartEmoji.active) {
               const hy = t.y + t.displayHeight * 0.30;
@@ -2639,7 +2639,7 @@ export function setupGame(){
           y:destY(),
           scaleX:0,
           scaleY:1.2,
-          duration:dur(200),
+          duration:dur(400),
           onComplete:()=>{
             GameState.love += isPos?1:-1;
             loveText.setText(String(GameState.love));
@@ -2696,7 +2696,7 @@ export function setupGame(){
           y: destY(),
           scale: 0,
           alpha: 0,
-          duration: dur(300),
+          duration: dur(600),
           onComplete: () => {
             bark.destroy();
             GameState.love -= 1;
@@ -3669,6 +3669,7 @@ function dogsBarkAtFalcon(){
           y:startY+Math.sin(ang)*dist,
           angle:Phaser.Math.Between(-180,180),
           alpha:0,
+          scale:0,
           duration:dur(800),
           ease:'Cubic.easeOut',
           onComplete:()=>{ const i=GameState.activeBursts.indexOf(cup); if(i!==-1) GameState.activeBursts.splice(i,1); cup.destroy(); }
@@ -3693,6 +3694,7 @@ function dogsBarkAtFalcon(){
           y:startY+Math.sin(ang)*dist,
           angle:Phaser.Math.Between(-180,180),
           alpha:0,
+          scale:0,
           duration:dur(500),
           ease:'Cubic.easeOut',
           onComplete:()=>{ const i=GameState.activeBursts.indexOf(cup); if(i!==-1) GameState.activeBursts.splice(i,1); cup.destroy(); }


### PR DESCRIPTION
## Summary
- slow down hearts and barks that fly to the heart cloud
- shrink coffee cups as they fade out
- remove grayscale duplicate of mini-game cup on the start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5ef8d6d8832fae8dcf5427ac99a1