### PR TITLE
Adjust truck duck rotation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1433,7 +1433,7 @@ export function setupGame(){
                 const targetScaleY = truckRef.scaleY * 0.96;
                 this.tweens.add({
                   targets: truckRef,
-                  angle: 6,
+                  angle: 1.2,
                   y: "+=6",
                   scaleX: targetScaleX,
                   scaleY: targetScaleY,


### PR DESCRIPTION
## Summary
- make the truck tilt less when ducking during the price sequence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5fd0b330832f862ada988989e0cf