### PR TITLE
Fix stray dogs persisting after fleeing

### DIFF
--- a/src/entities/dog.js
+++ b/src/entities/dog.js
@@ -431,6 +431,8 @@ export function updateDog(owner) {
 
 export function sendDogOffscreen(dog, x, y) {
   if (!dog) return;
+  // Mark immediately so other logic stops trying to interact with this dog
+  dog.dead = true;
   if (dog.followEvent) dog.followEvent.remove(false);
   // ensure any previous tweens don't fight with the exit tween
   this.tweens.killTweensOf(dog);


### PR DESCRIPTION
## Summary
- mark dogs as `dead` when sent offscreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5f97bd8c832f817193a8bdea2e84