### PR TITLE
Fix leftover portrait after endings

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -219,12 +219,6 @@ function showStartScreen(scene, opts = {}){
   scene = scene || this;
   const delayExtras = !!opts.delayExtras;
   if (typeof debugLog === 'function') debugLog('showStartScreen called');
-  if (GameState.carryPortrait) {
-    if (GameState.carryPortrait.scene) {
-      GameState.carryPortrait.destroy();
-    }
-    GameState.carryPortrait = null;
-  }
   if (miniGameCup && !miniGameCup.scene) {
     miniGameCup = null;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -4367,7 +4367,6 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -4459,7 +4458,6 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -4549,7 +4547,6 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -4658,7 +4655,6 @@ function dogsBarkAtFalcon(){
 
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         if(overlay){ this.tweens.add({targets:overlay,alpha:0,duration:dur(600)}); }
         createGlowTexture(this,0xffffff,'screen_flash',256);
@@ -4753,7 +4749,6 @@ function dogsBarkAtFalcon(){
 
     btn.on('pointerdown',()=>{
         btn.disableInteractive();
-        GameState.carryPortrait = img.setDepth(25);
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);

--- a/src/state.js
+++ b/src/state.js
@@ -30,7 +30,6 @@ export const GameState = {
   ,falconStunned: false
   ,badges: []
   ,badgeCounts: {}
-  ,carryPortrait: null
   ,lastEndKey: null
   ,phoneContainer: null
   ,activeBarks: []


### PR DESCRIPTION
## Summary
- remove carryPortrait state tracking
- drop code that stored/destroyed carryPortrait
- achievements now only use glow effect when active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d8372cb00832fa188513c024f46da