### PR TITLE
Add Lady Falcon theme music

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -93,6 +93,10 @@ export function preload(){
   loader.image('fired_end','assets/firedend.png');
   loader.audio('fired_intro',"assets/music/you're_fired_intro.mp3");
   loader.audio('fired_loop',"assets/music/you're_fired_loop.mp3");
+  loader.audio('falcon_intro','assets/music/LadyFalconTheme-intro.m4a');
+  loader.audio('falcon_bass','assets/music/LadyFalconTheme-bass.m4a');
+  loader.audio('falcon_drums','assets/music/LadyFalconTheme-drums.m4a');
+  loader.audio('falcon_synth','assets/music/LadyFalconTheme-Synth.m4a');
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('muse_victory','assets/musevictory.png');

--- a/src/intro.js
+++ b/src/intro.js
@@ -6,7 +6,7 @@ import { debugLog, DEBUG } from './debug.js';
 import { dur } from './ui.js';
 import { spawnSparrow, scatterSparrows } from './sparrow.js';
 import { createGrayscaleTexture, createGlowTexture } from './ui/helpers.js';
-import { playSong, stopSong } from './music.js';
+import { playSong, stopSong, setDrumVolume } from './music.js';
 
 let startOverlay = null;
 let startButton = null;
@@ -221,6 +221,7 @@ function showStartScreen(scene, opts = {}){
   scene = scene || this;
   const delayExtras = !!opts.delayExtras;
   if (typeof debugLog === 'function') debugLog('showStartScreen called');
+  playSong(scene, 'lady_falcon_theme');
   if (miniGameCup && !miniGameCup.scene) {
     miniGameCup = null;
   }
@@ -934,6 +935,7 @@ function showStartScreen(scene, opts = {}){
     startMsgTimers.forEach(t=>t.remove(false));
     startMsgTimers=[];
     startMsgBubbles=[];
+    setDrumVolume(1);
     for(let i=0;i<2;i++){
       spawnSparrow(scene,{ground:true});
     }

--- a/src/music.js
+++ b/src/music.js
@@ -1,8 +1,19 @@
 import { GameState } from './state.js';
 
 export function stopSong() {
-  if (GameState.songInstance && GameState.songInstance.stop) {
-    GameState.songInstance.stop();
+  if (Array.isArray(GameState.musicLoops)) {
+    GameState.musicLoops.forEach(s => {
+      if (s && s.stop) s.stop();
+    });
+  }
+  GameState.musicLoops = [];
+  GameState.drumLoop = null;
+  if (GameState.songInstance) {
+    if (GameState.songInstance.stop) {
+      GameState.songInstance.stop();
+    } else if (GameState.songInstance.intro && GameState.songInstance.intro.stop) {
+      GameState.songInstance.intro.stop();
+    }
   }
   GameState.songInstance = null;
   GameState.currentSong = null;
@@ -10,9 +21,7 @@ export function stopSong() {
 
 export function playSong(scene, key) {
   if (!scene || !scene.sound) return;
-  if (GameState.songInstance && GameState.songInstance.stop) {
-    GameState.songInstance.stop();
-  }
+  stopSong();
   GameState.currentSong = key;
   let intro;
   let loop;
@@ -27,7 +36,30 @@ export function playSong(scene, key) {
       }
     });
     intro.play();
+  } else if (key === 'lady_falcon_theme') {
+    intro = scene.sound.add('falcon_intro');
+    const bass = scene.sound.add('falcon_bass', { loop: true });
+    const drums = scene.sound.add('falcon_drums', { loop: true, volume: 0.1 });
+    const synth = scene.sound.add('falcon_synth', { loop: true });
+    GameState.songInstance = intro;
+    GameState.musicLoops = [bass, drums, synth];
+    GameState.drumLoop = drums;
+    intro.once('complete', () => {
+      if (GameState.songInstance === intro) {
+        GameState.songInstance = null;
+        bass.play();
+        drums.play();
+        synth.play();
+      }
+    });
+    intro.play();
   } else {
     GameState.songInstance = null;
+  }
+}
+
+export function setDrumVolume(vol) {
+  if (GameState.drumLoop && GameState.drumLoop.setVolume) {
+    GameState.drumLoop.setVolume(vol);
   }
 }

--- a/src/state.js
+++ b/src/state.js
@@ -43,6 +43,8 @@ export const GameState = {
   ,loveSeqStarted: false
   ,currentSong: null
   ,songInstance: null
+  ,musicLoops: []
+  ,drumLoop: null
 };
 
 export const floatingEmojis = [];


### PR DESCRIPTION
## Summary
- load Lady Falcon theme audio files
- manage theme playback in `music.js`
- start the theme on the start screen and bump drums to full volume after clock-in
- track new audio references in `GameState`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872d329edbc832f9faddd72583c262f