### PR TITLE
Sync number drop timing

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -129,7 +129,8 @@ function startOpeningAnimation(scene){
     onComplete: () => openingDog.setDepth(16)
   });
 
-  tl.add({ targets: {}, duration: 400 });
+  // Begin the number drop slightly before the dog finishes so it lands
+  // right as the dog animation completes
 
   // Shift the landing position slightly so the 2 settles a bit further
   // to the right and lower on the title card. Round the coordinates to
@@ -182,6 +183,9 @@ function startOpeningAnimation(scene){
     angle: -20,
     duration: 800,
     ease: 'Cubic.easeIn',
+    // Start before the previous tween ends so the landing finishes
+    // right after the dog settles
+    offset: '-=1100',
     onStart: () => {
       thrustEvent = scene.time.addEvent({ delay: 80, loop: true, callback: spawnThrust });
     },


### PR DESCRIPTION
## Summary
- start the title `2` drop early so it lands when the girl and dog finish

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872edd968d0832fbcb3f3648b95fc8a