### PR TITLE
Add Customer Revolt music and behavior

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -97,6 +97,10 @@ export function preload(){
   loader.audio('falcon_bass','assets/music/LadyFalconTheme-bass.m4a');
   loader.audio('falcon_drums','assets/music/LadyFalconTheme-drums.m4a');
   loader.audio('falcon_synth','assets/music/LadyFalconTheme-Synth.m4a');
+  loader.audio('revolt_intro','assets/music/Customer_revolt_intro.m4a');
+  loader.audio('revolt_drums','assets/music/Customer_revolt_loop-drums.m4a');
+  loader.audio('revolt_bass','assets/music/Customer_revolt_loop-guitar-bass.m4a');
+  loader.audio('revolt_synth','assets/music/Customer_revolt_loop-synth.m4a');
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('muse_victory','assets/musevictory.png');

--- a/src/music.js
+++ b/src/music.js
@@ -53,6 +53,23 @@ export function playSong(scene, key) {
       }
     });
     intro.play();
+  } else if (key === 'customer_revolt') {
+    intro = scene.sound.add('revolt_intro');
+    const bass = scene.sound.add('revolt_bass', { loop: true, volume: 0.6 });
+    const drums = scene.sound.add('revolt_drums', { loop: true, volume: 0.6 });
+    const synth = scene.sound.add('revolt_synth', { loop: true, volume: 0.6 });
+    GameState.songInstance = intro;
+    GameState.musicLoops = [bass, drums, synth];
+    GameState.drumLoop = drums;
+    intro.once('complete', () => {
+      if (GameState.songInstance === intro) {
+        GameState.songInstance = null;
+        bass.play();
+        drums.play();
+        synth.play();
+      }
+    });
+    intro.play();
   } else {
     GameState.songInstance = null;
   }
@@ -61,5 +78,26 @@ export function playSong(scene, key) {
 export function setDrumVolume(vol) {
   if (GameState.drumLoop && GameState.drumLoop.setVolume) {
     GameState.drumLoop.setVolume(vol);
+  }
+}
+
+export function updateRevoltMusicVolume() {
+  if (GameState.currentSong !== 'customer_revolt') return;
+  const [bass, drums, synth] = GameState.musicLoops || [];
+  const money = GameState.money || 0;
+  const love = GameState.love || 0;
+  if (drums && drums.setVolume) {
+    const dVol = Math.min(1, Math.max(0, money / 10)) * 0.6;
+    drums.setVolume(dVol);
+  }
+  if (bass && bass.setVolume) {
+    const bVol = Math.min(1, Math.max(0, love / 3)) * 0.6;
+    bass.setVolume(bVol);
+  }
+  if (synth && synth.setVolume) {
+    const mFac = Math.min(1, Math.max(0, (money - 10) / 10));
+    const lFac = Math.min(1, Math.max(0, (love - 10) / 10));
+    const sVol = mFac * lFac * 0.6;
+    synth.setVolume(sVol);
   }
 }


### PR DESCRIPTION
## Summary
- load new Customer Revolt music tracks
- add Customer Revolt case and volume updates
- play Customer Revolt music when the revolt begins and delay attacker rush
- adjust attacker positions and hopping behavior
- react to stat changes to adjust revolt music volumes

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872f74d4938832fb92b71fee58b5698