### PR TITLE
Add drum fade during orders

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ import { flashBorder, flashFill, blinkButton, applyRandomSkew, setDepthFromBotto
 
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { playOpening, showStartScreen, playIntro } from './intro.js';
-import { playSong, updateRevoltMusicVolume } from './music.js';
+import { playSong, updateRevoltMusicVolume, fadeDrums } from './music.js';
 import DesaturatePipeline from './desaturatePipeline.js';
 
 export let Assets, Scene, Customers, config;
@@ -1256,6 +1256,7 @@ export function setupGame(){
       // or while another dialog is already visible
       return;
     }
+    fadeDrums(this, 0.2, 800);
     if (typeof debugLog === 'function') {
       debugLog('showDialog start', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
     }
@@ -1709,6 +1710,7 @@ export function setupGame(){
   }
 
   function handleAction(type){
+    fadeDrums(this, 1, 800);
     const current=GameState.activeCustomer;
     if (current) {
       GameState.saleInProgress = true;

--- a/src/music.js
+++ b/src/music.js
@@ -82,6 +82,16 @@ export function setDrumVolume(vol) {
   }
 }
 
+export function fadeDrums(scene, vol, duration = 600) {
+  if (!scene || !GameState.drumLoop || !scene.tweens) return;
+  scene.tweens.add({
+    targets: GameState.drumLoop,
+    volume: vol,
+    duration,
+    ease: 'Linear',
+  });
+}
+
 export function updateRevoltMusicVolume() {
   if (GameState.currentSong !== 'customer_revolt') return;
   const [bass, drums, synth] = GameState.musicLoops || [];


### PR DESCRIPTION
## Summary
- add `fadeDrums` helper to animate drum volume
- lower drums when the order dialog appears
- restore drums when an action is selected

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872fbd3f184832fb08068a095e0da68