### PR TITLE
Reduce drum fade when viewing order

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1256,7 +1256,7 @@ export function setupGame(){
       // or while another dialog is already visible
       return;
     }
-    fadeDrums(this, 0.2, 800);
+    fadeDrums(this, 0.6, 800);
     if (typeof debugLog === 'function') {
       debugLog('showDialog start', GameState.queue.length, GameState.wanderers.length, GameState.activeCustomer);
     }


### PR DESCRIPTION
## Summary
- keep background rhythm more audible while the order is displayed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687300f456b0832fa5851c0e9d0ceea1