### PR TITLE
Fix emoji shadow and tweak birds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2682,6 +2682,7 @@ export function setupGame(){
       let h;
       if(idx===0 && emojiObj){
         h = emojiObj;
+        if(h.setShadow) h.setShadow(0,0,'#000',0);
       } else {
         const face = showFace();
         h = this.add.text(sx, sy, face, {font:'24px sans-serif', fill:'#fff'})

--- a/src/sparrow.js
+++ b/src/sparrow.js
@@ -311,7 +311,7 @@ export function updateSparrows(scene, delta){
     bird.update(dt);
     if(!bird.sprite) continue;
     const y = bird.sprite.y;
-    if(y < -50 || y > scene.scale.height + 50){
+    if(y < -80 || y > scene.scale.height + 80){
       if(bird.threatCheck && bird.threatCheck.remove){
         bird.threatCheck.remove(false);
       }
@@ -396,7 +396,7 @@ export function scatterSparrows(scene){
       if(i !== -1) birds.splice(i, 1);
       if(bird.destroy) bird.destroy();
       // Bring the bird back quickly but not all at once
-      const spawnDelay = Phaser.Math.Between(200, 400) * (idx + 1);
+      const spawnDelay = Phaser.Math.Between(1000, 4000) * (idx + 1);
       scene.time.delayedCall(spawnDelay, () => {
         if(birds.length < maxSparrows(gs.love)) {
           spawnSparrow(scene);


### PR DESCRIPTION
## Summary
- remove drop shadow when reaction emoji turns into a heart
- increase time before scattered birds respawn
- let birds fly farther offscreen before despawning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687330afa4d0832fb8bebff880912b5a