### PR TITLE
Reset queue state before restart

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5048,6 +5048,9 @@ function dogsBarkAtFalcon(){
     });
     GameState.queue=[];
     GameState.wanderers=[];
+    GameState.orderInProgress = false;
+    GameState.dialogActive = false;
+    GameState.girlReady = false;
     Object.keys(GameState.customerMemory).forEach(k=>{ delete GameState.customerMemory[k]; });
     GameState.heartWin = null;
     GameState.servedCount=0;


### PR DESCRIPTION
## Summary
- reset queue-related flags in `restartGame`
- ensure next game begins with clean state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873da34e258832fbae218bf917033c2