### PR TITLE
Fix start screen reset crash

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -1084,7 +1084,10 @@ function showStartScreen(scene, opts = {}){
     }
     const tl=scene.tweens.createTimeline({callbackScope:scene,onComplete:()=>{
       if (window.hideMiniGame) window.hideMiniGame();
-      if(startButton) startButton.destroy();
+      if(startButton){
+        startButton.destroy();
+        startButton = null;
+      }
       if(startOverlay){startOverlay.destroy(); startOverlay=null;}
       if(startWhite){startWhite.destroy(); startWhite=null;}
       if(openingTitle){ openingTitle.destroy(); openingTitle=null; }


### PR DESCRIPTION
## Summary
- nullify startButton after it's destroyed during intro cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873e85dc2b8832f8bb7b3744093d863