### PR TITLE
Add loading screen overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,29 @@
       body {
         background: linear-gradient(to bottom, #cfa87e, #5c3b2a);
       }
+      #loading-screen {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: #5c3b2a;
+        z-index: 200;
+      }
+      #loading-screen img {
+        width: 160px;
+        height: auto;
+        image-rendering: pixelated;
+      }
+      #loading-screen div {
+        margin-top: 20px;
+        font: bold 32px sans-serif;
+        color: #fff;
+      }
       #version1-frame {
         position: absolute;
         left: 0;
@@ -25,9 +48,17 @@
     </style>
 </head>
 <body>
+  <div id="loading-screen">
+    <img src="assets/coffeecup2.png" alt="Loading">
+    <div>Loading…</div>
+  </div>
   <div id="game-container" role="application" aria-label="Coffee Clicker game"></div>
   <iframe id="version1-frame" title="Mini Game"></iframe>
   <script>
+    window.hideLoadingScreen = function() {
+      const el = document.getElementById('loading-screen');
+      if (el) el.style.display = 'none';
+    };
     function positionMiniGame() {
       const f = document.getElementById('version1-frame');
       const canvas = document.querySelector('#game-container canvas');

--- a/src/main.js
+++ b/src/main.js
@@ -796,6 +796,9 @@ export function setupGame(){
     this.gameState = GameState;
     this.dur = dur;
     setSpeedMultiplier(1);
+    if (typeof window !== 'undefined' && window.hideLoadingScreen) {
+      window.hideLoadingScreen();
+    }
     if (DEBUG) addSpeedControl(this);
     const missing=requiredAssets.filter(key=>!this.textures.exists(key));
     if(missing.length){


### PR DESCRIPTION
## Summary
- show a loading screen overlay with a large coffee cup and "Loading…" at startup
- hide the loading screen once the main Phaser scene begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e899eb40832fa9e89649d5f2c775