### PR TITLE
Adjust achievement slot visibility

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -341,7 +341,10 @@ function showStartScreen(scene, opts = {}){
   }
   GameState.phoneContainer = phoneContainer;
 
-  const showSlots = GameState.startScreenSeen || GameState.badges.length > 0;
+  // Only display locked achievement slots after the player has
+  // earned at least two badges. This keeps the start screen clean
+  // when no achievements are unlocked yet.
+  const showSlots = GameState.badges.length > 1;
   const fadeSlots = showSlots && !GameState.slotsRevealed;
 
   // Removed animated bird sprites so the start button remains clickable


### PR DESCRIPTION
## Summary
- hide start-screen achievement slots until earning more than one badge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e945c130832fb7d7dfff707e7ab2