### PR TITLE
Add flirty greetings based on heart state

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -1032,6 +1032,7 @@ function showStartScreen(scene, opts = {}){
     }
 
     const nameComma = GameState.userName ? ', ' + GameState.userName : '';
+    const nameBang = GameState.userName ? GameState.userName + '! ' : '';
 
     const defaultMsgs=[
       [`u coming in${nameComma}? 🤔`, `where u at${nameComma}??`, 'mornin ☀️'],

--- a/src/main.js
+++ b/src/main.js
@@ -1328,9 +1328,31 @@ export function setupGame(){
       const itemStr=c.orders.map(o=>{
         return o.qty>1 ? `${o.qty} ${o.req}` : o.req;
       }).join(' and ');
-      wantLine=(c.orders.length===1 && c.orders[0].qty===1)
+      const orderLine=(c.orders.length===1 && c.orders[0].qty===1)
         ? `I want ${articleFor(c.orders[0].req)} ${c.orders[0].req}`
         : `I want ${itemStr}`;
+
+      const name = GameState.userName;
+      const state = (c.memory && c.memory.state) || CustomerState.NORMAL;
+      if(name){
+        if(state === CustomerState.GROWING){
+          const opts=[`listen ${name}`, `hey, ${name}, right?`];
+          const greet=Phaser.Utils.Array.GetRandom(opts);
+          wantLine=`${greet}\n${orderLine}`;
+        }else if(state === CustomerState.SPARKLING){
+          const opts=[`${name}, looking good`, `${name}, good to see you`, `hey ${name}, how's it going?`];
+          const greet=Phaser.Utils.Array.GetRandom(opts);
+          wantLine=`${greet}\n${orderLine}`;
+        }else if(state === CustomerState.ARROW){
+          const opts=[`${name}-senpai...`, '😳😳', '///'];
+          const greet=Phaser.Utils.Array.GetRandom(opts);
+          wantLine=`${greet}\n${orderLine}`;
+        }else{
+          wantLine=orderLine;
+        }
+      }else{
+        wantLine=orderLine;
+      }
     }
 
 


### PR DESCRIPTION
## Summary
- personalize wandering customer greetings with player's name when hearts are above normal
- fix missing variable `nameBang` in `intro.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874325e5ea0832f83c62878aedb7b7d