### PR TITLE
Fix lineGap initialization error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1360,6 +1360,7 @@ export function setupGame(){
     }
 
 
+    const lineGap = 10;
     dialogText
       .setOrigin(0.5)
       .setStyle({fontSize:'24px'})
@@ -1391,7 +1392,6 @@ export function setupGame(){
     const maxW = Math.max(dialogText.width, coinW);
     const hMargin = 20;
     const vMargin = 15;
-    const lineGap = 10;
     dialogBg.width = Math.max(maxW + hMargin * 2, 160);
     dialogBg.height = dialogText.height + (coinLine ? dialogCoins.height + lineGap : 0) + vMargin * 2;
 


### PR DESCRIPTION
## Summary
- initialize `lineGap` before using it in showDialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687479a23870832f892e0d1d2def81e2