### PR TITLE
Fix depth for coffee cup bursts

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -169,7 +169,7 @@ function startOpeningAnimation(scene){
     const ang = Phaser.Math.DegToRad(Phaser.Math.Between(0, 360));
     const dist = Phaser.Math.Between(80, 160);
     const cup = scene.add.image(openingNumber.x, openingNumber.y, "coffeecup2")
-      .setDepth(17)
+      .setDepth(22)
       .setScale(scale * 0.8)
       .setAlpha(1);
     if(phoneMask) cup.setMask(phoneMask);
@@ -192,7 +192,7 @@ function startOpeningAnimation(scene){
       const height = (scene.scale && scene.scale.height) ? scene.scale.height : 640;
       const x = Phaser.Math.Between(40, width - 40);
       const cup = scene.add.image(x, -20, 'coffeecup2')
-        .setDepth(18)
+        .setDepth(22)
         .setScale(Phaser.Math.FloatBetween(0.5, 0.8))
         .setAngle(Phaser.Math.Between(-180, 180));
       scene.tweens.add({

--- a/src/main.js
+++ b/src/main.js
@@ -3762,8 +3762,9 @@ function dogsBarkAtFalcon(){
         const dist = Phaser.Math.Between(10,40);
         const cup = s.add.image(startX,startY,'coffeecup2')
           .setOrigin(0.5)
-          .setDepth(21)
+          .setDepth(22)
           .setScale(0.36);
+        if (s.children && s.children.bringToTop) s.children.bringToTop(cup);
         GameState.activeBursts.push(cup);
         s.tweens.add({
           targets:cup,
@@ -3787,8 +3788,9 @@ function dogsBarkAtFalcon(){
         const dist = Phaser.Math.Between(20,80);
         const cup = s.add.image(startX,startY,'coffeecup2')
           .setOrigin(0.5)
-          .setDepth(21)
+          .setDepth(22)
           .setScale(0.5);
+        if (s.children && s.children.bringToTop) s.children.bringToTop(cup);
         GameState.activeBursts.push(cup);
         s.tweens.add({
           targets:cup,


### PR DESCRIPTION
## Summary
- spawn coffee thrust and confetti cups with depth 22
- raise depth for coffee explosion effects and bring sprites to front

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876994d6240832f879b9f21c9b881f2