### PR TITLE
Add Muse theme music

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -101,6 +101,10 @@ export function preload(){
   loader.audio('revolt_drums','assets/music/Customer_revolt_loop-drums.m4a');
   loader.audio('revolt_bass','assets/music/Customer_revolt_loop-guitar-bass.m4a');
   loader.audio('revolt_synth','assets/music/Customer_revolt_loop-synth.m4a');
+  loader.audio('muse_intro','assets/music/musetheme-intro.m4a');
+  loader.audio('muse_drum','assets/music/musetheme-loop-drum.m4a');
+  loader.audio('muse_synth','assets/music/musetheme-loop-synth.m4a');
+  loader.audio('muse_vocals','assets/music/musetheme-loop-vocals.m4a');
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('muse_victory','assets/musevictory.png');

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ import { flashBorder, flashFill, blinkButton, applyRandomSkew, setDepthFromBotto
 
 import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } from './assets.js';
 import { playOpening, showStartScreen, playIntro } from './intro.js';
-import { playSong, updateRevoltMusicVolume, fadeDrums } from './music.js';
+import { playSong, updateRevoltMusicVolume, updateMuseMusicVolume, fadeDrums } from './music.js';
 import DesaturatePipeline from './desaturatePipeline.js';
 
 export let Assets, Scene, Customers, config;
@@ -141,6 +141,7 @@ export function setupGame(){
     scene.time.delayedCall(dur(moveDur)*2,()=>{
       updateCloudStatus(scene);
       updateRevoltMusicVolume();
+      updateMuseMusicVolume();
       if(!isLove && GameState.money>=FIRED_THRESHOLD && !GameState.falconDefeated && !GameState.firedSeqStarted){
         startFiredSequence.call(scene);
       } else if(isLove && GameState.love>=MAX_L && !GameState.loveSeqStarted){
@@ -3928,6 +3929,7 @@ function dogsBarkAtFalcon(){
     scene.time.removeAllEvents();
     playSong(scene, 'customer_revolt');
     updateRevoltMusicVolume();
+    updateMuseMusicVolume();
     cleanupFloatingEmojis();
     cleanupBarks();
     cleanupBursts();
@@ -4497,6 +4499,8 @@ function dogsBarkAtFalcon(){
 
   function showLoveVictory(){
     const scene = this;
+    playSong(scene, 'muse_theme');
+    updateMuseMusicVolume();
     scene.tweens.killAll();
     scene.time.removeAllEvents();
     cleanupFloatingEmojis();

--- a/src/music.js
+++ b/src/music.js
@@ -79,6 +79,23 @@ export function playSong(scene, key, onLoopStart = null) {
       }
     });
     intro.play();
+  } else if (key === 'muse_theme') {
+    intro = scene.sound.add('muse_intro');
+    const drums = scene.sound.add('muse_drum', { loop: true, volume: 0.6 });
+    const synth = scene.sound.add('muse_synth', { loop: true, volume: 0.6 });
+    const vocals = scene.sound.add('muse_vocals', { loop: true, volume: 0.6 });
+    GameState.songInstance = intro;
+    GameState.musicLoops = [drums, synth, vocals];
+    GameState.drumLoop = drums;
+    intro.once('complete', () => {
+      if (GameState.songInstance === intro) {
+        GameState.songInstance = null;
+        drums.play();
+        synth.play();
+        vocals.play();
+      }
+    });
+    intro.play();
   } else {
     GameState.songInstance = null;
     if (typeof onLoopStart === 'function') onLoopStart();
@@ -121,5 +138,26 @@ export function updateRevoltMusicVolume() {
     const lFac = Math.min(1, Math.max(0, (love - 10) / 10));
     const sVol = mFac * lFac * 0.6;
     synth.setVolume(sVol);
+  }
+}
+
+export function updateMuseMusicVolume() {
+  if (GameState.currentSong !== 'muse_theme') return;
+  const [drums, synth, vocals] = GameState.musicLoops || [];
+  const money = GameState.money || 0;
+  const love = GameState.love || 0;
+  if (drums && drums.setVolume) {
+    const dVol = Math.min(1, Math.max(0, money / 10)) * 0.6;
+    drums.setVolume(dVol);
+  }
+  if (synth && synth.setVolume) {
+    const sVol = Math.min(1, Math.max(0, love / 3)) * 0.6;
+    synth.setVolume(sVol);
+  }
+  if (vocals && vocals.setVolume) {
+    const mFac = Math.min(1, Math.max(0, (money - 10) / 10));
+    const lFac = Math.min(1, Math.max(0, (love - 10) / 10));
+    const vVol = mFac * lFac * 0.6;
+    vocals.setVolume(vVol);
   }
 }


### PR DESCRIPTION
## Summary
- add Muse intro and loops to asset loader
- support `muse_theme` song in `music.js`
- adjust volumes during gameplay
- trigger Muse theme on love victory and when updating stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68769a13e730832fb6844db2fdf4efbf