### PR TITLE
Add zombie fade to Muse victory

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './debug.js';
 
 export const keys = [];
-export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','falcon_victory','revolt_end','fired_end','muse_victory','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
+export const requiredAssets = ['bg','truck','girl','lady_falcon','falcon_end','falcon_victory','revolt_end','fired_end','muse_victory','muse_victory_zombie','sparrow','dog1','price_ticket','pupcup','pupcup2','give','refuse','sell','cloudHeart','cloudDollar'];
 export const genzSprites = [
   'new_kid_0_0','new_kid_0_1','new_kid_0_2','new_kid_0_4','new_kid_0_5',
   'new_kid_1_0','new_kid_1_1','new_kid_1_2','new_kid_1_3','new_kid_1_4','new_kid_1_5',
@@ -108,6 +108,7 @@ export function preload(){
   // Correct file extension and name for falcon victory asset
   loader.image('falcon_victory','assets/falcon_victory.gif');
   loader.image('muse_victory','assets/musevictory.png');
+  loader.image('muse_victory_zombie','assets/musevictoryzombie.png');
   loader.image('revolt_end','assets/revolt.png');
   loader.image('price_ticket','assets/priceticket.png');
   loader.image('pupcup','assets/pupcup.png');

--- a/src/main.js
+++ b/src/main.js
@@ -4709,6 +4709,14 @@ function dogsBarkAtFalcon(){
     this.tweens.add({targets:img,alpha:1,duration:dur(1200*END_FADE_MULT)});
     awardBadge(this, img.texture.key);
 
+    const zombieImg = this.add.image(240,250,'muse_victory_zombie')
+      .setScale(2.4)
+      .setDepth(21)
+      .setAlpha(0);
+    this.time.delayedCall(dur(2000), () => {
+      this.tweens.add({targets:zombieImg,alpha:1,duration:dur(3000)});
+    });
+
     const line1 = this.add.text(240,450,'YOU ARE THE MUSE',
       {font:'28px sans-serif',fill:'#fff'})
       .setOrigin(0.5)


### PR DESCRIPTION
## Summary
- load `musevictoryzombie.png`
- fade in the zombie image a few seconds after the Muse victory image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a2550a9c832fbcd0a844b75a5617