### PR TITLE
Fix Muse victory sequence timing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4447,6 +4447,24 @@ function dogsBarkAtFalcon(){
     if(cloudHeartTween && cloudHeartTween.stop) cloudHeartTween.stop();
     if(cloudHeart) cloudHeart.setTintFill(0xff69b4);
 
+    // Clean up any lingering UI or dialogs
+    hideOverlayTexts();
+    clearDialog.call(this);
+    cleanupFloatingEmojis();
+    cleanupBarks();
+    cleanupBursts();
+    cleanupSparkles(this);
+    cleanupDogs(this);
+    cleanupSparrows(this);
+    if (GameState.spawnTimer) {
+      GameState.spawnTimer.remove(false);
+      GameState.spawnTimer = null;
+    }
+
+    // Start the victory music immediately
+    playSong(this, 'muse_theme');
+    updateMuseMusicVolume();
+
     const heartTimers = [];
     const emitHeart = target => {
       const hx = target.x + Phaser.Math.Between(-10,10);


### PR DESCRIPTION
## Summary
- trigger victory music and cleanup immediately when the love sequence begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a354622c832f891b6695d175a777