### PR TITLE
Increase coffee confetti size and remove intro name

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -185,7 +185,7 @@ function startOpeningAnimation(scene){
     const dist = Phaser.Math.Between(80, 160);
     const cup = scene.add.image(openingNumber.x, openingNumber.y, "coffeecup2")
       .setDepth(22)
-      .setScale(scale * 0.8)
+      .setScale(scale * 1.6) // doubled size
       .setAlpha(1);
     if(phoneMask) cup.setMask(phoneMask);
 
@@ -208,7 +208,7 @@ function startOpeningAnimation(scene){
       const x = Phaser.Math.Between(40, width - 40);
       const cup = scene.add.image(x, -20, 'coffeecup2')
         .setDepth(22)
-        .setScale(Phaser.Math.FloatBetween(0.5, 0.8))
+        .setScale(Phaser.Math.FloatBetween(1.0, 1.6)) // bigger coffee confetti
         .setAngle(Phaser.Math.Between(-180, 180));
       scene.tweens.add({
         targets: cup,
@@ -1104,12 +1104,8 @@ function showStartScreen(scene, opts = {}){
       }
       if (userName) {
         GameState.userName = userName;
-
-
-
-        addStartMessage(userName);
-
-
+        // Previously displayed the player's name as its own message bubble.
+        // Skip that bubble so the intro texts feel more natural.
       }
     } catch (err) {
       void err;

--- a/src/main.js
+++ b/src/main.js
@@ -3806,7 +3806,7 @@ function dogsBarkAtFalcon(){
         const cup = s.add.image(startX,startY,'coffeecup2')
           .setOrigin(0.5)
           .setDepth(22)
-          .setScale(0.36);
+          .setScale(0.72); // bigger coffee confetti
         if (s.children && s.children.bringToTop) s.children.bringToTop(cup);
         GameState.activeBursts.push(cup);
         s.tweens.add({
@@ -3832,7 +3832,7 @@ function dogsBarkAtFalcon(){
         const cup = s.add.image(startX,startY,'coffeecup2')
           .setOrigin(0.5)
           .setDepth(22)
-          .setScale(0.5);
+          .setScale(1.0); // bigger coffee confetti
         if (s.children && s.children.bringToTop) s.children.bringToTop(cup);
         GameState.activeBursts.push(cup);
         s.tweens.add({


### PR DESCRIPTION
## Summary
- make coffee confetti cups much larger during attacks and intro
- skip showing the player's name by itself in the intro phone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a4f7cdc4832f9e1485b3d964da50