### PR TITLE
Add music fade for Muse victory

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4462,7 +4462,7 @@ function dogsBarkAtFalcon(){
     }
 
     // Start the victory music immediately
-    playSong(this, 'muse_theme');
+    playSong(this, 'muse_theme', null, {fadeDuration: 10000});
     updateMuseMusicVolume();
 
     const heartTimers = [];
@@ -4640,7 +4640,7 @@ function dogsBarkAtFalcon(){
 
   function showLoveVictory(){
     const scene = this;
-    playSong(scene, 'muse_theme');
+    playSong(scene, 'muse_theme', null, {fadeDuration: 10000});
     updateMuseMusicVolume();
     scene.tweens.killAll();
     scene.time.removeAllEvents();


### PR DESCRIPTION
## Summary
- add fadeOutCurrentSong helper
- allow playSong to fade out existing loops
- fade down previous music when Muse victory starts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876a5a09ad8832f8f2447d02312b9ba