### PR TITLE
Fix Muse ending song restart

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4650,8 +4650,10 @@ function dogsBarkAtFalcon(){
   function showLoveVictory(){
     const scene = this;
 
-    playSong(scene, 'muse_theme', null, {fadeDuration: 10000});
-    updateMuseMusicVolume();
+    if (GameState.currentSong !== 'muse_theme') {
+      playSong(scene, 'muse_theme', null, {fadeDuration: 10000});
+      updateMuseMusicVolume();
+    }
     scene.tweens.killAll();
     scene.time.removeAllEvents();
     cleanupFloatingEmojis();


### PR DESCRIPTION
## Summary
- avoid replaying the Muse theme when showing the Love victory ending

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876ab70354c832f9c59763e5d1ae317