### PR TITLE
Fix intro dog variable

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -21,6 +21,9 @@ const START_SCREEN_DELAY = 600;
 // Fade duration when the opening assets disappear
 const DROP_FADE_DURATION = 200;
 
+// Slight vertical offset when positioning the dog above the titlecard
+const DOG_OFFSET_Y = -10;
+
 const OPENING_DROP_DELAY = 3000;
 
 


### PR DESCRIPTION
## Summary
- define missing `DOG_OFFSET_Y` constant in `intro.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876b1deba3c832fbeb83dc3affe511b