### PR TITLE
Implement slower wanderers in Muse ending

### DIFF
--- a/src/customers.js
+++ b/src/customers.js
@@ -45,7 +45,9 @@ export const WANDER_BOTTOM = 580;
 // Maximum number of wandering customers that can appear at once. This value is
 // fixed rather than scaling with the player's love.
 export const MAX_WANDERERS = 5;
-export const WALK_OFF_BASE = 800;
+// Base duration (ms) for customers walking off screen.
+// Increased so leaving characters move more slowly during ending scenes.
+export const WALK_OFF_BASE = 1600;
 export const MAX_M = 200;
 export const MAX_L = 100;
 // Money threshold that triggers the fired ending

--- a/src/main.js
+++ b/src/main.js
@@ -4529,12 +4529,7 @@ function dogsBarkAtFalcon(){
             .setDepth(c.sprite.depth+1);
         }
       };
-      const ht = this.time.addEvent({
-        delay:Phaser.Math.Between(800,1500),
-        loop:true,
-        callback:()=>emitHeart(c.sprite)
-      });
-      heartTimers.push(ht);
+      // Hearts will emit when the wanderer shuffles forward
       update();
     };
     const positiveStates = [CustomerState.MENDING, CustomerState.GROWING,
@@ -4569,10 +4564,11 @@ function dogsBarkAtFalcon(){
               if(!c.sprite || !c.sprite.scene){ shuffle.remove(false); return; }
               const off = Phaser.Math.Between(-6,6);
               this.tweens.add({targets:c.sprite,x:c.sprite.x+off,duration:dur(200),yoyo:true});
+              emitHeart(c.sprite);
             }
           });
           c.shuffleEvent = shuffle;
-          this.tweens.add({targets:c.sprite,x:targetX,y:targetY,duration:dur(13000)});
+          this.tweens.add({targets:c.sprite,x:targetX,y:targetY,duration:dur(26000)});
         }
       } else if(c && c.sprite){
         const dir=c.sprite.x<ORDER_X?-1:1;


### PR DESCRIPTION
## Summary
- slow down characters exiting the scene
- emit hearts during wanderer shuffle steps
- move wanderers to the girl more slowly during Muse ending

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876baa5fdfc832f988da46f69e2de0b