### PR TITLE
Heart cloud scale now follows drum volume

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -215,6 +215,13 @@ export function setupGame(){
     }
   }
 
+  function applyHeartScale(vol){
+    if(cloudHeart && cloudHeart.setScale){
+      const scale = cloudHeartBaseScale * (1 + 0.1 * vol);
+      cloudHeart.setScale(scale);
+    }
+  }
+
   function stopHighMoneyEffects(){
     if(highMoneyTween){
       if(highMoneyTween.remove) highMoneyTween.remove();
@@ -667,6 +674,7 @@ export function setupGame(){
   let moneyText, moneyDollar, loveText, cloudHeart, cloudDollar, queueLevelText;
   let moneyStatusText, moneyStatusTween = null;
   let cloudHeartBaseX = 0, cloudDollarBaseX = 0;
+  let cloudHeartBaseScale = 2.4;
   let dialogBg, dialogText, dialogCoins,
       dialogPriceLabel, dialogPriceValue, dialogPriceBox,
       dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket, dialogPriceShadow, dialogPupCup,
@@ -890,10 +898,11 @@ export function setupGame(){
       .setBlendMode(Phaser.BlendModes.NEGATIVE)
       .setAlpha(0);
     updateMoneyDisplay();
+    cloudHeartBaseScale = 2.4;
     cloudHeart=this.add.sprite(0,35,'cloudHeart')
       .setOrigin(1,0)
       .setDepth(1)
-      .setScale(2.4)
+      .setScale(cloudHeartBaseScale)
       // Use screen blend for lighter overlay
       .setBlendMode(Phaser.BlendModes.SCREEN)
 
@@ -906,6 +915,8 @@ export function setupGame(){
 
     cloudHeart.x = 320 + cloudHeart.displayWidth/2;
     cloudHeartBaseX = cloudHeart.x;
+    GameState.heartCloud = cloudHeart;
+    GameState.heartCloudBaseScale = cloudHeartBaseScale;
     loveText=this.add.text(0,0,GameState.love,{font:'26px Arial, sans-serif',fill:'#fff'})
       .setOrigin(0.5)
       .setDepth(2)

--- a/src/music.js
+++ b/src/music.js
@@ -162,6 +162,10 @@ export function setDrumVolume(vol) {
   if (GameState.drumLoop && GameState.drumLoop.setVolume) {
     GameState.drumLoop.setVolume(vol);
   }
+  if (GameState.heartCloud && GameState.heartCloud.setScale) {
+    const base = GameState.heartCloudBaseScale || GameState.heartCloud.scale;
+    GameState.heartCloud.setScale(base * (1 + 0.1 * vol));
+  }
 }
 
 export function fadeDrums(scene, vol, duration = 600) {
@@ -172,6 +176,15 @@ export function fadeDrums(scene, vol, duration = 600) {
     duration,
     ease: 'Linear',
   });
+  if (GameState.heartCloud && GameState.heartCloud.setScale) {
+    const base = GameState.heartCloudBaseScale || GameState.heartCloud.scale;
+    scene.tweens.add({
+      targets: GameState.heartCloud,
+      scale: base * (1 + 0.1 * vol),
+      duration,
+      ease: 'Linear',
+    });
+  }
 }
 
 export function updateRevoltMusicVolume() {

--- a/src/state.js
+++ b/src/state.js
@@ -25,6 +25,8 @@ export const GameState = {
   truck: null,
   falcon: null,
   girl: null
+  ,heartCloud: null
+  ,heartCloudBaseScale: 2.4
   ,girlHP: 10
   ,falconHP: 10
   ,falconStunned: false


### PR DESCRIPTION
## Summary
- track `heartCloud` sprite in `GameState`
- store the base heart cloud scale
- adjust heart cloud scale in `setDrumVolume` and `fadeDrums`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c219fce8832fa768682af9f86f42