### PR TITLE
Slow zombie steps during news ending

### DIFF
--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -62,7 +62,8 @@ export function startWander(scene, c, targetX, exitAfter){
   const amp = Phaser.Math.Between(15,30);
   const freq = Phaser.Math.FloatBetween ? Phaser.Math.FloatBetween(1.5,4.5) : Phaser.Math.Between(15,45)/10;
   // Slower wander speed now that the line is working
-  const walkDuration = Phaser.Math.Between(10000,14000);
+  let walkDuration = Phaser.Math.Between(10000,14000);
+  if(GameState.zombieMode) walkDuration *= 1.5;
   c.walkData={startX,startY,targetX,amp,freq,duration:walkDuration,exitAfter};
   if(scene && scene.tweens && scene.tweens.add && c.sprite){
     c.walkTween = scene.tweens.add({
@@ -86,7 +87,8 @@ export function resumeWanderer(scene, c){
   const {targetX,startX,startY,amp,freq,duration,exitAfter} = c.walkData;
   const totalDist = Math.abs(targetX - startX);
   const remaining = Math.abs(targetX - c.sprite.x);
-  const walkDuration = totalDist>0 ? duration * (remaining/totalDist) : duration;
+  let walkDuration = totalDist>0 ? duration * (remaining/totalDist) : duration;
+  if(GameState.zombieMode) walkDuration *= 1.5;
   if(scene && scene.tweens && scene.tweens.add && c.sprite){
     c.walkTween = scene.tweens.add({
       targets:c.sprite,

--- a/src/main.js
+++ b/src/main.js
@@ -4469,6 +4469,7 @@ function dogsBarkAtFalcon(){
     GameState.loveSeqStarted = true;
     GameState.gameOver = true; // prevent new orders
     GameState.orderInProgress = true;
+    GameState.zombieMode = true;
     if(cloudHeartTween && cloudHeartTween.stop) cloudHeartTween.stop();
     if(cloudHeart) cloudHeart.setTintFill(0xff69b4);
 
@@ -4557,13 +4558,15 @@ function dogsBarkAtFalcon(){
           const bottom = g.y + g.displayHeight/2;
           const targetY = bottom - c.sprite.displayHeight/2 - 2;
           const targetX = ORDER_X + Phaser.Math.Between(-20,20);
+          const shuffleDelay = GameState.zombieMode ? Phaser.Math.Between(1000,1500) : Phaser.Math.Between(300,600);
           const shuffle = this.time.addEvent({
-            delay:Phaser.Math.Between(300,600),
+            delay: shuffleDelay,
             loop:true,
             callback:()=>{
               if(!c.sprite || !c.sprite.scene){ shuffle.remove(false); return; }
-              const off = Phaser.Math.Between(-6,6);
-              this.tweens.add({targets:c.sprite,x:c.sprite.x+off,duration:dur(200),yoyo:true});
+              const off = GameState.zombieMode ? Phaser.Math.Between(-12,12) : Phaser.Math.Between(-6,6);
+              const stepDur = GameState.zombieMode ? dur(400) : dur(200);
+              this.tweens.add({targets:c.sprite,x:c.sprite.x+off,duration:stepDur,yoyo:true});
               emitHeart(c.sprite);
             }
           });

--- a/src/state.js
+++ b/src/state.js
@@ -47,6 +47,8 @@ export const GameState = {
   ,musicLoops: []
   ,drumLoop: null
 
+  ,zombieMode: false
+
   ,volume: 1
   ,userName: null
 


### PR DESCRIPTION
## Summary
- add `zombieMode` flag in game state
- trigger zombie mode when the love ending starts
- slow wanderer shuffle speed while in zombie mode
- slow wanderer walk speed during zombie mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c4587430832fb14ebd8004ef7d20