### PR TITLE
Add audio-based cloud pulsing

### DIFF
--- a/src/audioMeter.js
+++ b/src/audioMeter.js
@@ -1,0 +1,31 @@
+export function makeAudioMeter(sound) {
+  if (!sound || !sound.manager || !sound.manager.context) {
+    return () => 0;
+  }
+  const ctx = sound.manager.context;
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 256;
+  const bufferLength = analyser.frequencyBinCount;
+  const dataArray = new Uint8Array(bufferLength);
+  if (sound.source && sound.source.connect) {
+    sound.source.connect(analyser);
+  } else if (sound.audioBufferSourceNode && sound.audioBufferSourceNode.connect) {
+    sound.audioBufferSourceNode.connect(analyser);
+  } else if (sound._source && sound._source.connect) {
+    sound._source.connect(analyser);
+  } else if (sound.sourceNode && sound.sourceNode.connect) {
+    sound.sourceNode.connect(analyser);
+  } else if (sound.input && sound.input.connect) {
+    sound.input.connect(analyser);
+  }
+  analyser.connect(ctx.destination);
+  return () => {
+    analyser.getByteTimeDomainData(dataArray);
+    let sum = 0;
+    for (let i = 0; i < bufferLength; i++) {
+      const v = dataArray[i] - 128;
+      sum += Math.abs(v);
+    }
+    return sum / (bufferLength * 128);
+  };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -189,6 +189,14 @@ export function setupGame(){
     updateHighMoneyEffects(scene);
   }
 
+  function updateCloudPulse(){
+    if (!GameState.drumMeter) return;
+    const level = GameState.drumMeter();
+    const scale = 1 + level * 0.5;
+    if (cloudDollar) cloudDollar.setScale(cloudDollarBaseScale * scale);
+    if (cloudHeart) cloudHeart.setScale(cloudHeartBaseScale * scale);
+  }
+
   function updateCloudPositions(){
     if(cloudDollar){
       const ratio=Math.min(MAX_M,Math.max(0,GameState.money))/MAX_M;
@@ -667,6 +675,7 @@ export function setupGame(){
   let moneyText, moneyDollar, loveText, cloudHeart, cloudDollar, queueLevelText;
   let moneyStatusText, moneyStatusTween = null;
   let cloudHeartBaseX = 0, cloudDollarBaseX = 0;
+  let cloudHeartBaseScale = 1, cloudDollarBaseScale = 1;
   let dialogBg, dialogText, dialogCoins,
       dialogPriceLabel, dialogPriceValue, dialogPriceBox,
       dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket, dialogPriceShadow, dialogPupCup,
@@ -875,6 +884,7 @@ export function setupGame(){
     const dollarPipeline = cloudDollar.getPostPipeline(DesaturatePipeline);
     if (dollarPipeline) dollarPipeline.amount = 0.5;
 
+    cloudDollarBaseScale = cloudDollar.scaleX;
     cloudDollar.x = 160 - cloudDollar.displayWidth/2;
     cloudDollarBaseX = cloudDollar.x;
     const moneyStr = receipt(GameState.money);
@@ -903,6 +913,7 @@ export function setupGame(){
 
     const heartPipeline = cloudHeart.getPostPipeline(DesaturatePipeline);
     if (heartPipeline) heartPipeline.amount = 0.5;
+    cloudHeartBaseScale = cloudHeart.scaleX;
 
     cloudHeart.x = 320 + cloudHeart.displayWidth/2;
     cloudHeartBaseX = cloudHeart.x;
@@ -1230,6 +1241,7 @@ export function setupGame(){
       enforceCustomerScaling();
       updateDrinkEmojiPosition();
       updateSparrows(this, dt);
+      updateCloudPulse();
     });
 
 

--- a/src/music.js
+++ b/src/music.js
@@ -1,4 +1,5 @@
 import { GameState } from './state.js';
+import { makeAudioMeter } from './audioMeter.js';
 
 export const badgeSongMap = {
   revolt_end: 'customer_revolt',
@@ -27,6 +28,7 @@ export function stopSong() {
   }
   GameState.musicLoops = [];
   GameState.drumLoop = null;
+  GameState.drumMeter = null;
   if (GameState.songInstance) {
     if (GameState.songInstance.stop) {
       GameState.songInstance.stop();
@@ -52,6 +54,7 @@ export function fadeOutCurrentSong(scene, duration = 1000) {
   }
   GameState.musicLoops = [];
   GameState.drumLoop = null;
+  GameState.drumMeter = null;
   GameState.songInstance = null;
   GameState.currentSong = null;
   GameState.currentBadgeSong = null;
@@ -104,6 +107,7 @@ export function playSong(scene, key, onLoopStart = null, opts = {}) {
     GameState.songInstance = intro;
     GameState.musicLoops = [bass, drums, synth];
     GameState.drumLoop = drums;
+    GameState.drumMeter = makeAudioMeter(drums);
     intro.once('complete', () => {
       if (GameState.songInstance === intro) {
         GameState.songInstance = null;
@@ -124,6 +128,7 @@ export function playSong(scene, key, onLoopStart = null, opts = {}) {
     GameState.songInstance = intro;
     GameState.musicLoops = [bass, drums, synth];
     GameState.drumLoop = drums;
+    GameState.drumMeter = makeAudioMeter(drums);
     intro.once('complete', () => {
       if (GameState.songInstance === intro) {
         GameState.songInstance = null;
@@ -141,6 +146,7 @@ export function playSong(scene, key, onLoopStart = null, opts = {}) {
     GameState.songInstance = intro;
     GameState.musicLoops = [drums, synth, vocals];
     GameState.drumLoop = drums;
+    GameState.drumMeter = makeAudioMeter(drums);
     intro.once('complete', () => {
       if (GameState.songInstance === intro) {
         GameState.songInstance = null;

--- a/src/state.js
+++ b/src/state.js
@@ -46,6 +46,7 @@ export const GameState = {
   ,songInstance: null
   ,musicLoops: []
   ,drumLoop: null
+  ,drumMeter: null
 
   ,volume: 1
   ,userName: null


### PR DESCRIPTION
## Summary
- create `audioMeter` utility to sample audio amplitude
- track `drumMeter` in `GameState`
- pulse HUD clouds in `updateCloudPulse` using drum peaks
- hook the pulse update in the main scene
- attach audio meters when songs start and clear them when stopping music

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c360e6a4832fb40d9714e4b3bc93