### PR TITLE
Fix startup crash by defining missing variable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -684,6 +684,7 @@ export function setupGame(){
   let cloudHeartBaseX = 0, cloudDollarBaseX = 0;
 
   let cloudHeartBaseScale = 2.4;
+  let cloudDollarBaseScale = 2.4;
   let dialogBg, dialogText, dialogCoins,
       dialogPriceLabel, dialogPriceValue, dialogPriceBox,
       dialogDrinkEmoji, dialogPriceContainer, dialogPriceTicket, dialogPriceShadow, dialogPupCup,


### PR DESCRIPTION
## Summary
- define `cloudDollarBaseScale`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876dac87628832f93bd71324b2cfd61