### PR TITLE
Fix duplicate pulseText export

### DIFF
--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -179,4 +179,4 @@ export function pulseText(textObj, level=1){
   });
 }
 
-export { blinkButton as default, heartbeatDuration, pulseText };
+export default blinkButton;


### PR DESCRIPTION
## Summary
- remove duplicate named exports for `pulseText`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877262edc5c832fa6e1aa3d97d8c523