### PR TITLE
Add coffee cup rocket effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        background: #5c3b2a;
+        background: #fff;
         z-index: 200;
       }
       #loading-screen img {
@@ -33,7 +33,15 @@
       #loading-screen div {
         margin-top: 20px;
         font: bold 32px sans-serif;
-        color: #fff;
+        color: #000;
+      }
+      @keyframes rocket {
+        0% { transform: scale(1) translateY(0); opacity: 1; }
+        20% { transform: scale(1.2) translateY(-20px); }
+        100% { transform: scale(1) translateY(-600px); opacity: 0; }
+      }
+      #loading-screen img.rocket {
+        animation: rocket 1.5s ease-in forwards;
       }
       #version1-frame {
         position: absolute;
@@ -57,7 +65,16 @@
   <script>
     window.hideLoadingScreen = function() {
       const el = document.getElementById('loading-screen');
-      if (el) el.style.display = 'none';
+      if (!el) return;
+      const img = el.querySelector('img');
+      if (img) {
+        img.classList.add('rocket');
+        img.addEventListener('animationend', () => {
+          el.style.display = 'none';
+        }, { once: true });
+      } else {
+        el.style.display = 'none';
+      }
     };
     function positionMiniGame() {
       const f = document.getElementById('version1-frame');


### PR DESCRIPTION
## Summary
- use a white background for the loading screen
- animate the coffee cup to rocket away once loading finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687727458648832fb934869b27ec79a1