### PR TITLE
Adjust nickname pulse behavior

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -1042,10 +1042,11 @@ function showStartScreen(scene, opts = {}){
         const meas = scene.add.text(0,0,text.split(name)[0],{font:'20px sans-serif',wordWrap:{width:wrapWidth}}).setOrigin(0,0.5).setVisible(false);
         const off = meas.width;
         meas.destroy();
-        const pulse = scene.add.text(-bw/2 + pad + off,0,name,{font:'20px sans-serif',fill:textColor})
-          .setOrigin(0,0.5);
+        const pulse = scene.add.text(0,0,name,{font:'20px sans-serif',fill:textColor})
+          .setOrigin(0.5,0.5);
+        pulse.x = -bw/2 + pad + off + pulse.width/2;
         bubble.add(pulse);
-        pulseText(pulse, GameState.loveLevel);
+        if(GameState.loveLevel > 1) pulseText(pulse, GameState.loveLevel);
       }
       repositionMessages();
       return bubble;

--- a/src/ui/helpers.js
+++ b/src/ui/helpers.js
@@ -167,11 +167,15 @@ export function heartbeatDuration(level=1){
 
 export function pulseText(textObj, level=1){
   if(!textObj || !textObj.scene || !textObj.scene.tweens) return;
+  if(level <= 1) return; // Neutral level shouldn't pulse
   const scene=textObj.scene;
   const dur=heartbeatDuration(level);
+  let scale=1.05;
+  if(level>=4) scale=1.15;
+  else if(level>=3) scale=1.1;
   scene.tweens.add({
     targets:textObj,
-    scale:1.1,
+    scale:scale,
     duration:dur/2,
     yoyo:true,
     repeat:-1,


### PR DESCRIPTION
## Summary
- do not pulse text at neutral love level
- position nickname text at its center
- soften pulse at low levels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687729e10080832fa9c051be0d0d56e1