### PR TITLE
Adjust zombie speed and clear Muse crowd

### DIFF
--- a/src/entities/wanderers.js
+++ b/src/entities/wanderers.js
@@ -61,9 +61,9 @@ export function startWander(scene, c, targetX, exitAfter){
   const startY=c.sprite.y;
   const amp = Phaser.Math.Between(15,30);
   const freq = Phaser.Math.FloatBetween ? Phaser.Math.FloatBetween(1.5,4.5) : Phaser.Math.Between(15,45)/10;
-  // Slower wander speed now that the line is working
+  // Base wander speed
   let walkDuration = Phaser.Math.Between(10000,14000);
-  if(GameState.zombieMode) walkDuration *= 1.5;
+  if(GameState.zombieMode) walkDuration *= 0.625; // 60% faster
   c.walkData={startX,startY,targetX,amp,freq,duration:walkDuration,exitAfter};
   if(scene && scene.tweens && scene.tweens.add && c.sprite){
     c.walkTween = scene.tweens.add({
@@ -88,7 +88,7 @@ export function resumeWanderer(scene, c){
   const totalDist = Math.abs(targetX - startX);
   const remaining = Math.abs(targetX - c.sprite.x);
   let walkDuration = totalDist>0 ? duration * (remaining/totalDist) : duration;
-  if(GameState.zombieMode) walkDuration *= 1.5;
+  if(GameState.zombieMode) walkDuration *= 0.625; // 60% faster
   if(scene && scene.tweens && scene.tweens.add && c.sprite){
     c.walkTween = scene.tweens.add({
       targets:c.sprite,

--- a/src/main.js
+++ b/src/main.js
@@ -4589,14 +4589,16 @@ function dogsBarkAtFalcon(){
           const bottom = g.y + g.displayHeight/2;
           const targetY = bottom - c.sprite.displayHeight/2 - 2;
           const targetX = ORDER_X + Phaser.Math.Between(-20,20);
-          const shuffleDelay = GameState.zombieMode ? Phaser.Math.Between(1000,1500) : Phaser.Math.Between(300,600);
+          const shuffleDelay = GameState.zombieMode
+            ? Phaser.Math.Between(625,938) // 60% faster
+            : Phaser.Math.Between(300,600);
           const shuffle = this.time.addEvent({
             delay: shuffleDelay,
             loop:true,
             callback:()=>{
               if(!c.sprite || !c.sprite.scene){ shuffle.remove(false); return; }
               const off = GameState.zombieMode ? Phaser.Math.Between(-12,12) : Phaser.Math.Between(-6,6);
-              const stepDur = GameState.zombieMode ? dur(400) : dur(200);
+              const stepDur = GameState.zombieMode ? dur(250) : dur(200); // 60% faster when zombified
               this.tweens.add({targets:c.sprite,x:c.sprite.x+off,duration:stepDur,yoyo:true});
               emitHeart(c.sprite);
             }
@@ -4824,6 +4826,10 @@ function dogsBarkAtFalcon(){
     GameState.queue.forEach(addToCrowd);
     GameState.wanderers.forEach(addToCrowd);
     if(GameState.activeCustomer) addToCrowd(GameState.activeCustomer);
+    // Clear queue and wanderers once everyone joins the crowd
+    GameState.queue = [];
+    GameState.wanderers = [];
+    GameState.activeCustomer = null;
 
     // Do not spawn additional crowd members once the screen is covered
 


### PR DESCRIPTION
## Summary
- clear customer queue & wanderers when the Muse ending begins
- speed up zombie-mode shuffle animations and wander movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687729597b14832fb7193d63b2ef7388