### PR TITLE
Ensure price ticket pops in front of truck

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1320,7 +1320,9 @@ export function setupGame(){
       dialogPriceContainer
         .setAngle(0)
         .setScale(1)
-        .setAlpha(1);
+        .setAlpha(1)
+        // ensure the price ticket starts above the truck next time
+        .setDepth(11);
     }
   }
 


### PR DESCRIPTION
## Summary
- make `resetPriceBox` restore the original depth of the price ticket container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c5dc8cb4832f9fb1e5340efdb181