### PR TITLE
Gameplay tweaks

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -302,32 +302,25 @@ function dropOpeningNumber(scene){
   openingNumber.setOrigin(0, 1);
   openingNumber.setPosition(bottomLeftX, bottomLeftY);
 
-  const fallTl = scene.tweens.createTimeline();
-  fallTl.add({ targets: openingNumber, angle: 45, duration: 400, ease: 'Sine.easeIn' });
-  fallTl.add({ targets: openingNumber, angle: 25, duration: 250, ease: 'Sine.easeOut' });
-  fallTl.add({ targets: openingNumber, angle: 55, duration: 250, ease: 'Sine.easeInOut' });
-  fallTl.add({ targets: openingNumber, angle: 35, duration: 250, ease: 'Sine.easeInOut' });
-  fallTl.add({ targets: openingNumber, angle: 70, duration: 300, ease: 'Sine.easeIn' });
-  fallTl.add({
+  scene.tweens.add({
     targets: openingNumber,
     y: scene.scale.height + openingNumber.displayHeight,
     angle: 90,
-    duration: 700,
-    ease: 'Cubic.easeIn'
-  });
-  fallTl.setCallback('onComplete', () => {
-    if(openingNumber){ openingNumber.destroy(); openingNumber = null; }
-    if(introFadeEvent) introFadeEvent.remove(false);
-    const targets = [openingTitle, openingDog].filter(Boolean);
-    if(targets.length){
-        scene.tweens.add({
-          targets,
-          alpha: 0,
-          duration: DROP_FADE_DURATION
-        });
+    duration: 2000,
+    ease: 'Cubic.easeIn',
+    onComplete: () => {
+      if(openingNumber){ openingNumber.destroy(); openingNumber = null; }
+      if(introFadeEvent) introFadeEvent.remove(false);
+      const targets = [openingTitle, openingDog].filter(Boolean);
+      if(targets.length){
+          scene.tweens.add({
+            targets,
+            alpha: 0,
+            duration: DROP_FADE_DURATION
+          });
+      }
     }
   });
-  fallTl.play();
 }
 
 function showStartScreen(scene, opts = {}){
@@ -1162,10 +1155,11 @@ function showStartScreen(scene, opts = {}){
 
 
     const defaultMsgs=[
-      [`u coming in${nameComma()}? 🤔`, `where u at${nameComma()}??`, 'mornin ☀️'],
-      ['better not still be in bed 😜', 'yo coffee girl ☕', `stop ghostin me${nameComma()}`],
+      ['u coming in? 🤔', 'where u at??', 'mornin ☀️'],
+      ['better not still be in bed 😜', 'yo coffee girl ☕', 'quit ghostin me!'],
       ['late night? 🥱💃', 'phone dead again? 🔋', 'omg wait till u hear about this guy 😏'],
-      ['u good?', 'hope everythin\'s chill', '…sry 😬']
+      ['u good?', "hope everythin's chill", '…sry 😬'],
+      ['bring me coffee asap', 'need my caffeine', 'wake up call pls']
 
     ];
 
@@ -1173,33 +1167,38 @@ function showStartScreen(scene, opts = {}){
       ['falc-a-doodle-doo?', `${nameBang()}wtf?!?`, '☕🩸🦅', 'skreeee 🦅', '**poke**'],
       ['what happened yesterday?', `angel saw falcons in the park last night`, 'elanor said the falcon got u!!', '🪶💥🪶 🪶💥🪶'],
       ['was that THE lady falcon?', 'is Lady Falcon... royalty?', "don't lose ALL the money", "...she's from another dimension"],
-      ['better keep an eye on the register', 'stop giving so much away, bruh', `at least have enough money${nameComma()}...`, 'balance, girl', "you're not a sparrow"]
+      ['better keep an eye on the register', 'stop giving so much away, bruh', `at least have enough money${nameComma()}...`, 'balance, girl', "you're not a sparrow"],
+      ['still seeing feathers around', 'falcon watch 24/7', 'keep your guard up']
     ];
 
     const victoryMsgs=[
       [`run it ur way${nameComma()} 🚚✨`],
       [`give every drink away if u want${nameComma()} ☕❤️`],
-      ['cash can drop negative, no worries 💸🤙']
+      ['cash can drop negative, no worries 💸🤙'],
+      ['victory lap when?', 'coffee queen vibes']
     ];
 
     const revoltMsgs=[
       [`they got the truck back${nameComma()}`, 'ppl been whisperin bout a revolt?', 'heard the crowd went wild', 'yeah...'],
       ['dude u pissed off the park', `everyone was mad yesterday${nameComma()}`, 'maybe chill a bit', 'word is u bailed on them'],
       ['try showin some love', 'remember when service mattered?', `hand out a few smiles${nameComma()}`, "don't treat folks like dirt"],
-      ['keep em happy or they\'ll riot again', 'learn and be chill next shift', 'better vibes or bust', `make ppl happy${nameComma()} or they won't be happy...`]
+      ['keep em happy or they\'ll riot again', 'learn and be chill next shift', 'better vibes or bust', `make ppl happy${nameComma()} or they won't be happy...`],
+      ['crowds still restless', 'maybe toss a freebie', 'smiles are free']
     ];
 
     const firedMsgs=[
       ['u really handed the corp all ur $$', 'overlord vibes much?', `did they at least say thx${nameComma()}?`, 'you got fired for making money?'],
       ['keep some of that cash for urself', 'stop feeding the corporate machine', `seriously did u ask for ur job back${nameComma()}?`, "can't just give away all ur worth"],
       ['capitalism 101: hoard ur coins', 'no more freebies 4 the boss', 'share the love?', `so, did they rehire u${nameComma()}?`],
-      ['remember ur value!', "don't let them take it all", `get that job back or bounce${nameComma()}`, "you're entitled to that job!"]
+      ['remember ur value!', "don't let them take it all", `get that job back or bounce${nameComma()}`, "you're entitled to that job!"],
+      ['maybe freelance barista life?', 'corporate who?', 'follow the beans']
     ];
 
     const loveMsgs=[
       [`everyone stan coffee girl${nameComma()} ❤️`, ' 💑💑💑', 'literally hearts 💕'],
       ['park gossip is all love songs', `u got the whole crowd cheering${nameComma()}`, 'love > money fr 😍'],
-      ['coffee tastes sweeter when ur in love ☕💖', `they keep asking about you${nameComma()} 💖`, 'ur trending']
+      ['coffee tastes sweeter when ur in love ☕💖', `they keep asking about you${nameComma()} 💖`, 'ur trending'],
+      ['spreadin love like latte foam', 'park hearts overflowin']
 
     ];
 

--- a/src/main.js
+++ b/src/main.js
@@ -262,7 +262,9 @@ export function setupGame(){
     const cx = cloud.x + cloud.displayWidth * (0.5 - (cloud.originX || 0));
     const cy = cloud.y + cloud.displayHeight * (0.5 - (cloud.originY || 0));
     for(let i=0;i<count;i++){
-      const puff = createCloudPuff(scene, cx, cy);
+      const startX = cx + Phaser.Math.Between(-6,6);
+      const startY = cy + Phaser.Math.Between(-6,6);
+      const puff = createCloudPuff(scene, startX, startY);
       const ang = Phaser.Math.FloatBetween(0, Math.PI*2);
       const dist = Phaser.Math.Between(15, 40);
       scene.tweens.add({
@@ -1399,7 +1401,12 @@ export function setupGame(){
 
     let wantLine;
     if(c.isDog){
-      const sounds=['woof woof!','bark bark!','arf arf!','ruff ruff!','awoo!','🐶🐶'];
+      const n=currentName();
+      const sounds=[
+        'woof woof!','bark bark!','arf arf!','ruff ruff!','awoo!','🐶🐶',
+        n?`sniff sniff, ${n}?`:'sniff sniff',
+        'wag wag!'
+      ];
       const sound=Phaser.Utils.Array.GetRandom(sounds);
       wantLine=sound;
     } else {
@@ -4953,9 +4960,8 @@ function dogsBarkAtFalcon(){
     const titleOver = this.add.text(240,300,'OVER',{
       font:'100px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
     }).setOrigin(0.5).setDepth(21).setAlpha(0);
-    this.tweens.add({targets:titleGame,alpha:1,duration:dur(1800)});
-    this.tweens.add({targets:titleOver,alpha:1,duration:dur(1800),delay:dur(1800)});
-    const fadeOutDelay = dur(3600);
+    this.tweens.add({targets:[titleGame,titleOver],alpha:1,duration:dur(1800)});
+    const fadeOutDelay = dur(1800);
     this.tweens.add({targets:[titleGame,titleOver],alpha:0,duration:dur(600),delay:fadeOutDelay});
 
     const img = this.add.image(240,250,'fired_end')
@@ -5042,9 +5048,8 @@ function dogsBarkAtFalcon(){
     const titleOver = this.add.text(240,300,'OVER',{
       font:'100px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
     }).setOrigin(0.5).setDepth(21).setAlpha(0);
-    this.tweens.add({targets:titleGame,alpha:1,duration:dur(1800)});
-    this.tweens.add({targets:titleOver,alpha:1,duration:dur(1800),delay:dur(1800)});
-    const fadeOutDelay = dur(3600);
+    this.tweens.add({targets:[titleGame,titleOver],alpha:1,duration:dur(1800)});
+    const fadeOutDelay = dur(1800);
     this.tweens.add({targets:[titleGame,titleOver],alpha:0,duration:dur(600),delay:fadeOutDelay});
 
     const imgFadeDur = dur(2400);
@@ -5075,37 +5080,18 @@ function dogsBarkAtFalcon(){
     const maxTextWidth = wrapWidth;
     if(line1.width > maxTextWidth) line1.setScale(maxTextWidth / line1.width);
     if(line2.width > maxTextWidth) line2.setScale(maxTextWidth / line2.width);
-    const cup = this.add.image(0,0,'coffeecup2').setScale(1.6);
-    const bubble = this.add.graphics();
-    const bubbleText = this.add.text(0,0,'Try Again',{font:'20px sans-serif',fill:'#000'}).setOrigin(0.5);
-    const pad = 10;
-    const bw = bubbleText.width + pad*2;
-    const bh = bubbleText.height + pad*2;
-    const bubbleX = cup.displayWidth/2 + bw/2 + 8;
-    bubble.fillStyle(0xffffff,1);
-    bubble.lineStyle(2,0x000000,1);
-    bubble.fillRoundedRect(-bw/2 + bubbleX,-bh/2,bw,bh,16);
-    bubble.strokeRoundedRect(-bw/2 + bubbleX,-bh/2,bw,bh,16);
-    bubble.fillTriangle(-bw/2 + bubbleX,-5,-bw/2 + bubbleX,5,-bw/2 + bubbleX-10,0);
-    bubble.beginPath();
-    bubble.moveTo(-bw/2 + bubbleX,-5);
-    bubble.lineTo(-bw/2 + bubbleX-10,0);
-    bubble.lineTo(-bw/2 + bubbleX,5);
-    bubble.strokePath();
-    bubbleText.setPosition(bubbleX,0);
-
-    const btn = this.add.container(240,550,[cup,bubble,bubbleText])
-      .setDepth(22)
-      .setAlpha(0);
-    btn.setSize(cup.displayWidth + bw + 10, Math.max(cup.displayHeight,bh) + 10);
-    const btnZone = this.add.zone(0,0,btn.width,btn.height).setOrigin(0.5);
-    btnZone.setInteractive({ useHandCursor:true });
-    btn.add(btnZone);
+    const btn = this.add.text(240,550,'Try Again',{
+      font:'20px sans-serif',
+      fill:'#000',
+      backgroundColor:'#ffffff',
+      padding:{x:14,y:8}
+    }).setOrigin(0.5).setDepth(22).setAlpha(0);
+    btn.setInteractive({ useHandCursor:true });
 
     const showBtnDelay = line2Delay + dur(600) + 1000;
     this.tweens.add({targets:btn,alpha:1,duration:dur(600),delay:showBtnDelay});
-    btnZone.on('pointerdown',()=>{
-        btnZone.disableInteractive();
+    btn.on('pointerdown',()=>{
+        btn.disableInteractive();
         btn.setVisible(false);
         createGlowTexture(this,0xffffff,'screen_flash',256);
         const overlayG = this.add.image(btn.x,btn.y,'screen_flash').setDepth(23);
@@ -5270,9 +5256,8 @@ function dogsBarkAtFalcon(){
     const titleOver = this.add.text(240,300,'OVER',{
       font:'100px sans-serif',fill:'#f00',stroke:'#000',strokeThickness:8
     }).setOrigin(0.5).setDepth(21).setAlpha(0);
-    this.tweens.add({targets:titleGame,alpha:1,duration:dur(1800)});
-    this.tweens.add({targets:titleOver,alpha:1,duration:dur(1800),delay:dur(1800)});
-    const fadeOutDelay = dur(3600);
+    this.tweens.add({targets:[titleGame,titleOver],alpha:1,duration:dur(1800)});
+    const fadeOutDelay = dur(1800);
     this.tweens.add({targets:[titleGame,titleOver],alpha:0,duration:dur(600),delay:fadeOutDelay});
 
     const img = this.add.image(240,250,'revolt_end')
@@ -5392,7 +5377,8 @@ function dogsBarkAtFalcon(){
     loveText.setText(String(GameState.love));
     moneyText.setColor('#fff');
     loveText.setColor('#fff');
-    if(cloudDollar){ cloudDollar.setVisible(true); }
+    if(cloudDollar){ cloudDollar.setVisible(true).setAlpha(1); }
+    if(cloudHeart){ cloudHeart.setVisible(true).setAlpha(1); }
     if(moneyText){ moneyText.setVisible(true); }
     if(moneyDollar){ moneyDollar.setVisible(true); }
     stopHighMoneyEffects();

--- a/src/sparrow.js
+++ b/src/sparrow.js
@@ -414,17 +414,15 @@ export function scatterSparrows(scene){
       -40
     );
     bird.flyAway(target);
-    const destroyDelay = Phaser.Math.Between(900, 1200);
-    scene.time.delayedCall(destroyDelay, () => {
-      fadeOutBird(scene, bird, () => {
-        const spawnDelay = Phaser.Math.Between(1000, 4000) * (idx + 1);
-        scene.time.delayedCall(spawnDelay, () => {
-          if(birds.length < maxSparrows(gs.love)) {
-            spawnSparrow(scene);
-          }
-        }, [], scene);
-      });
-    }, [], scene);
+    fadeOutBird(scene, bird, () => {
+      const baseDelay = Phaser.Math.Between(2000, 4000);
+      const spawnDelay = baseDelay + idx * Phaser.Math.Between(1000,2000);
+      scene.time.delayedCall(spawnDelay, () => {
+        if(birds.length < maxSparrows(gs.love)) {
+          spawnSparrow(scene);
+        }
+      }, [], scene);
+    });
   });
 }
 

--- a/src/ui/volumeSlider.js
+++ b/src/ui/volumeSlider.js
@@ -12,7 +12,7 @@ export function showVolumeSlider(value=1,onChange){
     slider.step='0.05';
     Object.assign(slider.style,{
       position:'absolute',
-      bottom:'60px',
+      bottom:'120px',
       left:'50%',
       transform:'translateX(-50%)',
       width:'120px',


### PR DESCRIPTION
## Summary
- smooth intro "2" drop
- sync GAME/OVER fade timing
- adjust falcon defeat button style
- slow bird return and fade them properly
- widen puff emitter spread
- show volume control higher
- refresh clouds on restart
- expand intro phone messages and dog barks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687801efa28c832f83af0fde45e97c76