### PR TITLE
Centralize mood transitions (advance/cycle) and add unit tests

### DIFF
--- a/src/domain/mood.js
+++ b/src/domain/mood.js
@@ -1,0 +1,52 @@
+import { CustomerState } from '../constants.js';
+
+/**
+ * Saturating mood progression for successful drink interactions.
+ *
+ * Policy decision: ARROW is terminal for growth and remains ARROW.
+ */
+export function advanceMood(state) {
+  switch (state) {
+    case CustomerState.BROKEN:
+      return CustomerState.MENDING;
+    case CustomerState.MENDING:
+      return CustomerState.NORMAL;
+    case CustomerState.NORMAL:
+      return CustomerState.GROWING;
+    case CustomerState.GROWING:
+      return CustomerState.SPARKLING;
+    case CustomerState.SPARKLING:
+      return CustomerState.ARROW;
+    case CustomerState.ARROW:
+      return CustomerState.ARROW;
+    default:
+      return state;
+  }
+}
+
+/**
+ * Looping mood progression used where continuous rotation is desired.
+ *
+ * Policy decision: ARROW cycles back to BROKEN so every state can reappear.
+ */
+export function cycleMood(state) {
+  switch (state) {
+    case CustomerState.BROKEN:
+      return CustomerState.MENDING;
+    case CustomerState.MENDING:
+      return CustomerState.NORMAL;
+    case CustomerState.NORMAL:
+      return CustomerState.GROWING;
+    case CustomerState.GROWING:
+      return CustomerState.SPARKLING;
+    case CustomerState.SPARKLING:
+      return CustomerState.ARROW;
+    case CustomerState.ARROW:
+      return CustomerState.BROKEN;
+    default:
+      return CustomerState.NORMAL;
+  }
+}
+
+// Backwards-compatible alias for existing usage/tests that refer to nextMood.
+export const nextMood = advanceMood;

--- a/src/entities/customerQueue.js
+++ b/src/entities/customerQueue.js
@@ -21,6 +21,7 @@ import { showDialog, Assets } from '../main.js';
 import { startWander, loopsForState } from './wanderers.js';
 import { DOG_TYPES, updateDog, scaleDog } from './dog.js';
 import { setDepthFromBottom } from '../ui/helpers.js';
+import { cycleMood } from '../domain/mood.js';
 
 
 
@@ -39,18 +40,6 @@ const HEART_EMOJIS = {
   [CustomerState.SPARKLING]: '💖',
   [CustomerState.ARROW]: '💘'
 };
-
-function cycleMood(state){
-  switch(state){
-    case CustomerState.BROKEN: return CustomerState.MENDING;
-    case CustomerState.MENDING: return CustomerState.NORMAL;
-    case CustomerState.NORMAL: return CustomerState.GROWING;
-    case CustomerState.GROWING: return CustomerState.SPARKLING;
-    case CustomerState.SPARKLING: return CustomerState.ARROW;
-    case CustomerState.ARROW: return CustomerState.BROKEN;
-    default: return CustomerState.NORMAL;
-  }
-}
 
 export function maxWanderers() {
   return customersMaxWanderers();
@@ -649,4 +638,3 @@ export function spawnCustomer() {
   // immediately pulled into line. The intro or queue logic will lure them when
   // they wander close enough.
 }
-

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ import { keys, requiredAssets, preload as preloadAssets, receipt, emojiFor } fro
 import { playOpening, showStartScreen, playIntro } from './intro.js';
 import { playSong, updateRevoltMusicVolume, updateMuseMusicVolume, fadeDrums, fadeOutCurrentSong } from './music.js';
 import DesaturatePipeline from './desaturatePipeline.js';
+import { advanceMood } from './domain/mood.js';
 
 export let Assets, Scene, Customers, config;
 export let showStartScreenFn, handleActionFn, spawnCustomerFn, scheduleNextSpawnFn, showDialogFn, animateLoveChangeFn, blinkButtonFn;
@@ -68,16 +69,7 @@ const UPSET_EMOJIS = ['😠','🤬','😡','😤','😭','😢','😱','😖','�
 // Returns the player's chosen name if available, falling back to a nickname
 const currentName = () => GameState.userName || GameState.nickname || '';
 
-export function nextMood(state){
-  switch(state){
-    case CustomerState.BROKEN: return CustomerState.MENDING;
-    case CustomerState.MENDING: return CustomerState.NORMAL;
-    case CustomerState.NORMAL: return CustomerState.GROWING;
-    case CustomerState.GROWING: return CustomerState.SPARKLING;
-    case CustomerState.SPARKLING: return CustomerState.ARROW;
-    default: return state;
-  }
-}
+export const nextMood = advanceMood;
 
 export function setupGame(){
   if (typeof debugLog === 'function') debugLog('main.js loaded');

--- a/test/run-unit.js
+++ b/test/run-unit.js
@@ -1,9 +1,11 @@
 const { runUnitTests } = require('./unit/core.test');
 const { runModuleLoaderUnitTests } = require('./unit/moduleLoader.test');
+const { runMoodUnitTests } = require('./unit/mood.test');
 
 try {
   runUnitTests();
   runModuleLoaderUnitTests();
+  runMoodUnitTests();
 } catch (err) {
   console.error(err);
   process.exit(1);

--- a/test/unit/core.test.js
+++ b/test/unit/core.test.js
@@ -66,19 +66,6 @@ function testSpawnCustomerEmptyAvailable() {
   assert.strictEqual(context.wanderers.length, 0);
 }
 
-function testNextMoodProgression() {
-  const { nextMood } = loadModuleExports('src/main.js', {
-    CustomerState: { NORMAL: 0, GROWING: 1, SPARKLING: 2, ARROW: 3, BROKEN: 4, MENDING: 5 },
-    window: undefined,
-    document: { readyState: 'loading' }
-  });
-  const CS = { NORMAL: 0, GROWING: 1, SPARKLING: 2, ARROW: 3 };
-  assert.strictEqual(nextMood(CS.NORMAL), CS.GROWING);
-  assert.strictEqual(nextMood(CS.GROWING), CS.SPARKLING);
-  assert.strictEqual(nextMood(CS.SPARKLING), CS.ARROW);
-  assert.strictEqual(nextMood(CS.ARROW), CS.ARROW);
-}
-
 function testEmojiFor() {
   const { emojiFor } = loadModuleExports('src/assets.js');
   assert.strictEqual(emojiFor('Iced Mocha'), '🍫 🧊 🧊\n☕');
@@ -92,7 +79,6 @@ function runUnitTests() {
   testSpawnCustomerQueuesWhenEmpty();
   testSpawnCustomerEmptyAvailable();
   testBlinkButton();
-  testNextMoodProgression();
   testEmojiFor();
   console.log('Unit tests passed');
 }

--- a/test/unit/mood.test.js
+++ b/test/unit/mood.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const { loadModuleExports } = require('../helpers/moduleLoader');
+
+function runMoodUnitTests() {
+  const CustomerState = {
+    NORMAL: 'normal',
+    BROKEN: 'broken',
+    MENDING: 'mending',
+    GROWING: 'growing',
+    SPARKLING: 'sparkling',
+    ARROW: 'arrow'
+  };
+
+  const { advanceMood, cycleMood, nextMood } = loadModuleExports('src/domain/mood.js', { CustomerState });
+
+  const advanceCases = [
+    [CustomerState.BROKEN, CustomerState.MENDING],
+    [CustomerState.MENDING, CustomerState.NORMAL],
+    [CustomerState.NORMAL, CustomerState.GROWING],
+    [CustomerState.GROWING, CustomerState.SPARKLING],
+    [CustomerState.SPARKLING, CustomerState.ARROW],
+    [CustomerState.ARROW, CustomerState.ARROW]
+  ];
+
+  advanceCases.forEach(([from, to]) => {
+    assert.strictEqual(advanceMood(from), to, `advanceMood(${from}) should be ${to}`);
+    assert.strictEqual(nextMood(from), to, `nextMood alias should match advanceMood for ${from}`);
+  });
+
+  const cycleCases = [
+    [CustomerState.BROKEN, CustomerState.MENDING],
+    [CustomerState.MENDING, CustomerState.NORMAL],
+    [CustomerState.NORMAL, CustomerState.GROWING],
+    [CustomerState.GROWING, CustomerState.SPARKLING],
+    [CustomerState.SPARKLING, CustomerState.ARROW],
+    [CustomerState.ARROW, CustomerState.BROKEN]
+  ];
+
+  cycleCases.forEach(([from, to]) => {
+    assert.strictEqual(cycleMood(from), to, `cycleMood(${from}) should be ${to}`);
+  });
+
+  assert.strictEqual(cycleMood('unknown-state'), CustomerState.NORMAL);
+  assert.strictEqual(advanceMood('unknown-state'), 'unknown-state');
+}
+
+module.exports = { runMoodUnitTests };


### PR DESCRIPTION
### Motivation
- Reduce duplicated mood-transition logic by providing a single source of truth for how customer moods advance or loop. 
- Make policy explicit about whether `ARROW` is terminal or loops back so gameplay behaviour is consistent and testable. 

### Description
- Added `src/domain/mood.js` which exports two named policies: `advanceMood` (saturating progression where `ARROW -> ARROW`) and `cycleMood` (looping progression where `ARROW -> BROKEN`), and a backwards-compatible alias `nextMood = advanceMood`.
- Replaced inline logic in `src/main.js` by importing `advanceMood` and exporting `nextMood` as an alias to it.
- Replaced the local `cycleMood` in `src/entities/customerQueue.js` with an import from `src/domain/mood.js` so both customers and dogs use the shared policy for debug/click transitions.
- Added unit tests `test/unit/mood.test.js` covering all `CustomerState` transitions for both policies and unknown-state behavior, wired into the unit test runner and removed the old `nextMood` progression test from `test/unit/core.test.js`.

### Testing
- Ran `npm run test:unit` and the unit suite passed (`Unit tests passed`).
- Ran `npm run lint` which completed successfully and reported only pre-existing warnings (no new lint errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9d806c98832fbd1eaff556323bad)